### PR TITLE
Change discord invite to WFCD so there's no need for an extra server

### DIFF
--- a/views/partials/footer.hbs
+++ b/views/partials/footer.hbs
@@ -8,7 +8,7 @@
 			<span> | </span>
             <a href="https://github.com/WFCD/warframe-hub" rel="nofollow" target="_blank">Github</a>
             <span> | </span>
-            <a href="https://discord.gg/ch7BWcS" rel="nofollow" target="_blank">Discord</a>
+            <a href="https://discord.gg/jGZxH9f" rel="nofollow" target="_blank">Discord</a>
             <span> | </span>
             <a href="#credits" data-target="#wfcd" data-toggle="modal" style="outline:none;">WFCD</a>
         </div>


### PR DESCRIPTION
### Warframe Hub Pull Request
---
---

**Summary (short):** Move discord to the WFCD server

---
**Description:** This'll give some visibility for the server and let the community know that we're happy to take reports and fixes.

---
**Fixes issue (include link):**
N/A

---
**Mockups, screenshots, evidence:**
No different UI

---

(Check one)
- [ ] Issue fix
- [x] Suggestion fulfillment
