### PR TITLE
remove default label text-shadow important flag (retro)

### DIFF
--- a/assets/css/main.retro.css
+++ b/assets/css/main.retro.css
@@ -239,7 +239,7 @@ button.close, .close:hover, .close:focus {
 /* Green */
 
 .label-success {
-	color: #0a0 !important;
+  color: #0a0 !important;
   text-shadow: 0px 0px 15px #ff9c00 !important;
 }
 
@@ -261,7 +261,7 @@ button.close, .close:hover, .close:focus {
 
 .label {
 	color: #0a0 !important;
-  text-shadow: 0px 0px 15px #009dff!important;
+  text-shadow: 0px 0px 15px #009dff;
 	background: none !important;
 	font-weight: normal !important;
 	font-family: "Hack";


### PR DESCRIPTION
### Warframe Hub Pull Request
---
---

**Summary (short):** fixes labels not respecting warning/error/etc colors

---
**Mockups, screenshots, evidence:**  see deployment
---

(Check one)
- [x] Issue fix
- [ ] Suggestion fulfillment
