### PR TITLE
chore: pin sinon to 5.0.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "gulp-minify": "git://github.com/zbennett10/gulp-minify.git#e1d8905041af230fd0fb980aa8a26c12c53e03f7",
     "hbs": "^4.0.1",
     "serve-favicon": "~2.5.0",
-    "sinon": "^5.0.1",
+    "sinon": "5.0.9",
     "supertest": "^3.0.0",
     "winston": "^2.4.2"
   },


### PR DESCRIPTION
### Warframe Hub Pull Request
---
**Summary (short):** Dependency pin

---
**Fixes issue (include link):** Bad build if CI tries to use 5.0.10 #117 

---

(Check one)
- [x] Issue fix
- [ ] Suggestion fulfillment
