### PR TITLE
fix: attack percentage based on api data instead of calculated data

### DIFF
--- a/assets/js/updaters.js
+++ b/assets/js/updaters.js
@@ -936,9 +936,7 @@ function updateInvasions() {
         invasionRow += '</div>';
 
         invasionRow += `<div class="row" style="margin-left:5px; margin-right:5px"><div class="progress" id="${invasion.id}_progress">`;
-        const attackPercent =
-              Math.floor(((invasion.count + invasion.requiredRuns)
-               / (invasion.requiredRuns * 2)) * 100);
+        const attackPercent = invasion.completion;
         const defendPercent = 100 - attackPercent;
         let attackWinning = '';
         let defendWinning = '';
@@ -959,7 +957,7 @@ function updateInvasions() {
           const sound = JSON.parse(localStorage.getItem('soundoptions') || '[]').includes('sound_invasion');
           const rewards = `${invasion.attackerReward.asString.length ? `${invasion.attackerReward.asString} vs ` : ''}${invasion.defenderReward.asString}`;
           sendNotification(
-            `${invasion.desc} • ${invasion.node}\n${invasion.attackingFaction} vs ${invasion.defendingFaction}\n${invasion.eta} Remaining`,
+            `${invasion.desc} • ${invasion.node}\n${invasion.attackingFaction} vs ${invasion.defendingFaction}\n${invasion.eta.replace('-Infinityd', '??').replace('Infinityd', '??')} Remaining`,
             `${rewards}`, sound ? 'audio/TextMessage_SingleDrumHit.mp3' : undefined,
           );
           addNotifiedId(invasion.id);

--- a/assets/js/updaters.js
+++ b/assets/js/updaters.js
@@ -879,9 +879,7 @@ function updateInvasions() {
           $(`#${invasion.id}`).remove();
         } else {
           $(`#${invasion.id}_info`).html(`<b>${invasion.node}</b><br>${invasion.desc} (Ends in: ${invasion.eta.replace('-Infinityd', '??').replace('Infinityd', '??')})`);
-          const attackPercent =
-                Math.floor(((invasion.count + invasion.requiredRuns)
-                 / (invasion.requiredRuns * 2)) * 100);
+          const attackPercent = invasion.completion;
           const defendPercent = 100 - attackPercent;
 
           const attackBar = $(`#${invasion.id}_progress`).children()[0];


### PR DESCRIPTION
### Warframe Hub Pull Request
---
**Summary (short):** Fix the invasion data being based on a calculation instead of provided data.

---
**Fixes issue (include link):** closes #125 


---
**Mockups, screenshots, evidence:** See deployment


---

**Issue Fix**
