### PR TITLE
fix: remove seconds from end time estimate

### DIFF
--- a/assets/js/updaters.js
+++ b/assets/js/updaters.js
@@ -874,7 +874,7 @@ function updateInvasions() {
     }
 
     invasions.forEach(invasion => {
-      const endTimeEstimate = `(Ends in: ${invasion.eta.replace('-Infinityd', '??').replace('Infinityd', '??').replace(/\s\d\ds/ig, '')})*`;
+      const endTimeEstimate = `(Ends in: ${invasion.eta.replace('-Infinityd', '??').replace('Infinityd', '??').replace(/\s\d\d?s/ig, '')})*`;
 
       if ($(`#${invasion.id}`).length !== 0) {
         if (invasion.completed) {

--- a/assets/js/updaters.js
+++ b/assets/js/updaters.js
@@ -874,7 +874,7 @@ function updateInvasions() {
     }
 
     invasions.forEach(invasion => {
-      const endTimeEstimate = `(Ends in: ${invasion.eta.replace('-Infinityd', '??').replace('Infinityd', '??')})*`;
+      const endTimeEstimate = `(Ends in: ${invasion.eta.replace('-Infinityd', '??').replace('Infinityd', '??').replace(/\s\d\ds/ig, '')})*`;
 
       if ($(`#${invasion.id}`).length !== 0) {
         if (invasion.completed) {


### PR DESCRIPTION
### Warframe Hub Pull Request
---
**Summary (short):** Remove seconds from the invasions Estimation


---
**Description:**


---
**Fixes issue (include link):** closes #131 


---
**Mockups, screenshots, evidence:** See deployment


---

(Check one)
- [x] Issue fix
- [x] Suggestion fulfillment
