### PR TITLE
Adjust size of fissure icons for more readability

### DIFF
--- a/assets/css/common.css
+++ b/assets/css/common.css
@@ -1,4 +1,5 @@
-.fissure-icon, .nightmare, .archwing, .standing { height: 16px; width: 16px; margin-top: -3px; }
+.nightmare, .archwing, .standing { height: 16px; width: 16px; margin-top: -3px; }
+.fissure-icon { height: 32px; width: 32px; margin-top: -3px; margin-right: 3px; }
 .plat { height: 20px; width: 20px; }
 .sortie-faction { height: 20px; width: 20px; }
 


### PR DESCRIPTION
### Adjust size of fissure icons for more readability
---
**Summary (short):**
See #135.

---
**Description:**
I went with the lower end of Tobi's suggested 32–40px because I didn't want the icons to occupy too much space.

---
**Fixes issue (include link):**
#135

---
**Mockups, screenshots, evidence:**


---

(Check one)
- [ ] Issue fix
- [x] Suggestion fulfillment
