### PR TITLE
Quick and dirty fix for #142 and #143

### DIFF
--- a/assets/js/updaters.js
+++ b/assets/js/updaters.js
@@ -876,8 +876,8 @@ function getProgressBarColor(faction) {
 
 function updateInvasions() {
   const {invasions} = worldState;
+  const invasionIDs = [];
   let numInvasions = 0;
-  let invasionIDs = [];
 
   if (invasions.length !== 0) {
     document.getElementById('invasiontitle').innerText = '*End time is estimated';

--- a/assets/js/updaters.js
+++ b/assets/js/updaters.js
@@ -999,7 +999,7 @@ function updateInvasions() {
         if (!invasionIDs.includes(invasion.id)) {
           $(`#${invasion.id}`).remove();
         }
-    });
+      });
 
     $('#invasionList [data-toggle="popover"]').popover();
 

--- a/assets/js/updaters.js
+++ b/assets/js/updaters.js
@@ -989,10 +989,13 @@ function updateInvasions() {
       }
     });
 
+    // debugging
+    console.log(invasionIDs);
+
     // remove invasions if they are not in the current invasion id list
     // this is for obviously expired invasions that no longer exists in the worldstate.
-    $('#invasionList').children().toArray().forEach(invasion => {
-      if(!(invasion.id in invasionIDs)){
+    $('#invasionList').children().not('#invasionbody').toArray().forEach(invasion => {
+      if (!(invasion.id in invasionIDs)) {
         $(`#${invasion.id}`).remove();
       }
     });

--- a/assets/js/updaters.js
+++ b/assets/js/updaters.js
@@ -121,7 +121,7 @@ function updateEvents() {
           addNotifiedId(event.id);
         }
       } else if (event.expired) {
-        $(`#event-${event.id}-title"`).remove();
+        $(`#event-${event.id}-title`).remove();
       }
     });
     $('#event-title').hide();
@@ -877,6 +877,7 @@ function getProgressBarColor(faction) {
 function updateInvasions() {
   const {invasions} = worldState;
   let numInvasions = 0;
+  let invasionIDs = [];
 
   if (invasions.length !== 0) {
     document.getElementById('invasiontitle').innerText = '*End time is estimated';
@@ -886,6 +887,8 @@ function updateInvasions() {
     }
 
     invasions.forEach(invasion => {
+      // store current invasion ids
+      invasionIDs.push(invasion.id);
       const endTimeEstimate = `(Ends in: ${invasion.eta.replace('-Infinityd', '??').replace('Infinityd', '??').replace(/\s\d\d?s/ig, '')})*`;
 
       if ($(`#${invasion.id}`).length !== 0) {
@@ -983,6 +986,14 @@ function updateInvasions() {
 
         $('#invasionbody').before(invasionRow);
         numInvasions += 1;
+      }
+    });
+
+    // remove invasions if they are not in the current invasion id list
+    // this is for obviously expired invasions that no longer exists in the worldstate.
+    $('#invasionList').children().forEach(invasion => {
+      if(!(invasion.id in invasionIDs)){
+        $(`#${invasion.id}`).remove();
       }
     });
 

--- a/assets/js/updaters.js
+++ b/assets/js/updaters.js
@@ -991,7 +991,7 @@ function updateInvasions() {
 
     // remove invasions if they are not in the current invasion id list
     // this is for obviously expired invasions that no longer exists in the worldstate.
-    $('#invasionList').children().forEach(invasion => {
+    $('#invasionList').children().toArray().forEach(invasion => {
       if(!(invasion.id in invasionIDs)){
         $(`#${invasion.id}`).remove();
       }

--- a/assets/js/updaters.js
+++ b/assets/js/updaters.js
@@ -991,10 +991,14 @@ function updateInvasions() {
 
     // remove invasions if they are not in the current invasion id list
     // this is for obviously expired invasions that no longer exists in the worldstate.
-    $('#invasionList').children().not('#invasionbody').toArray().forEach(invasion => {
-      if (!invasionIDs.includes(invasion.id)) {
-        $(`#${invasion.id}`).remove();
-      }
+    $('#invasionList')
+      .children()
+      .not('#invasionbody')
+      .toArray()
+      .forEach(invasion => {
+        if (!invasionIDs.includes(invasion.id)) {
+          $(`#${invasion.id}`).remove();
+        }
     });
 
     $('#invasionList [data-toggle="popover"]').popover();

--- a/assets/js/updaters.js
+++ b/assets/js/updaters.js
@@ -995,7 +995,7 @@ function updateInvasions() {
     // remove invasions if they are not in the current invasion id list
     // this is for obviously expired invasions that no longer exists in the worldstate.
     $('#invasionList').children().not('#invasionbody').toArray().forEach(invasion => {
-      if (!(invasion.id in invasionIDs)) {
+      if (!invasionIDs.includes(invasion.id)) {
         $(`#${invasion.id}`).remove();
       }
     });

--- a/assets/js/updaters.js
+++ b/assets/js/updaters.js
@@ -989,9 +989,6 @@ function updateInvasions() {
       }
     });
 
-    // debugging
-    console.log(invasionIDs);
-
     // remove invasions if they are not in the current invasion id list
     // this is for obviously expired invasions that no longer exists in the worldstate.
     $('#invasionList').children().not('#invasionbody').toArray().forEach(invasion => {

--- a/assets/js/updaters.js
+++ b/assets/js/updaters.js
@@ -876,7 +876,7 @@ function getProgressBarColor(faction) {
 
 function updateInvasions() {
   const {invasions} = worldState;
-  const invasionIDs = [];
+  const invasionIDs = {};
   let numInvasions = 0;
 
   if (invasions.length !== 0) {
@@ -888,7 +888,7 @@ function updateInvasions() {
 
     invasions.forEach(invasion => {
       // store current invasion ids
-      invasionIDs.push(invasion.id);
+      invasionIDs[invasion.id] = true;
       const endTimeEstimate = `(Ends in: ${invasion.eta.replace('-Infinityd', '??').replace('Infinityd', '??').replace(/\s\d\d?s/ig, '')})*`;
 
       if ($(`#${invasion.id}`).length !== 0) {
@@ -990,13 +990,13 @@ function updateInvasions() {
     });
 
     // remove invasions if they are not in the current invasion id list
-    // this is for obviously expired invasions that no longer exists in the worldstate.
+    // this is for obviously expired invasions that no longer exist in the worldstate.
     $('#invasionList')
       .children()
       .not('#invasionbody')
       .toArray()
       .forEach(invasion => {
-        if (!invasionIDs.includes(invasion.id)) {
+        if (!(invasion.id in invasionIDs)) {
           $(`#${invasion.id}`).remove();
         }
       });


### PR DESCRIPTION
### Warframe Hub Pull Request
---
**Summary (short):**

This supposedly fixes #142 and #143 

---
**Description:**

Fixed #143 by removing the extra quotation mark
Fixed #142 by first adding the current update session invasion IDs into an array, and then compare ids with the entire invasionList unordered list object. If there exists an ID not in the array, then the ID is obviously expired.

---
**Fixes issue (include link):**


---
**Mockups, screenshots, evidence:**


---

(Check one)
- [x] Issue fix
- [ ] Suggestion fulfillment
