### PR TITLE
fix: sortie not refreshing, acolyte health showing unprocessed float

### DIFF
--- a/assets/js/updaters.js
+++ b/assets/js/updaters.js
@@ -498,7 +498,7 @@ function updateAcolytes() {
 
           $('#acolytebody').before(acolyteRow);
           if (isNotifiable(acolyte.pid, 'enemies')) {
-            sendNotification(`${acolyte.healthPercent}% Health Remaining • Discovered at ${acolyte.lastDiscoveredAt}`, `${acolyte.agentType} discovered!`);
+            sendNotification(`${health}% Health Remaining • Discovered at ${acolyte.lastDiscoveredAt}`, `${acolyte.agentType} discovered!`);
             addNotifiedId(acolyte.pid);
           }
         } else {
@@ -673,7 +673,7 @@ function updateSortie() {
   if (sortie.variants.length !== 0) {
     $('#sortietitle').hide();
 
-    if (platformSwapped || $('#sortieList').children().length === 0) {
+    if (platformSwapped || $('#sortieList').children().length === 0 || !$(`#sortieTimer${sortie.id}`).length) {
       $('#sortieBoss').html(sortie.boss);
       $('#sortieFaction').html(getImage(
         'factions',


### PR DESCRIPTION
### Warframe Hub Pull Request
---
**Description:**
- Fix sortie not refreshing when there's a new sortie
- Fix acolyte notification using unprocessed health value

---
**Fixes issue (include link):**
None logged

---
**Mockups, screenshots, evidence:**
see deployment

---

(Check one)
- [x] Issue fix
- [ ] Suggestion fulfillment
