### PR TITLE
Fix Acolyte health color

### DIFF
--- a/assets/js/updaters.js
+++ b/assets/js/updaters.js
@@ -477,7 +477,7 @@ function updateAcolytes() {
           labelClass = 'info';
         } else if (health <= 50 && health > 20) {
           labelClass = 'warning';
-        } else if (health <= 0.00) {
+        } else if (health <= 20) {
           labelClass = 'danger';
         }
 


### PR DESCRIPTION
### Warframe Hub Pull Request
---
**Summary (short):**


---
**Description:**


---
**Fixes issue (include link):**
The health color of an acolyte is green if the health is between 0% and 20%.

---
**Mockups, screenshots, evidence:**


---

(Check one)
- [x] Issue fix
- [ ] Suggestion fulfillment
