### PR TITLE
Increase update period

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -348,7 +348,7 @@ if (!String.prototype.padStart) {
 
 // Main data refresh loop
 function initializeUpdateLoop() {
-  const updatePeriod = 30000;
+  const updatePeriod = 60000;
   let nextUpdateTimestamp = 0;
   (function updateCheck() {
     const currentTimestamp = new Date().getTime();


### PR DESCRIPTION

### Increase update period
---
**Summary (short):**
This essentially halves the number of requests on active tabs because the API caches for a minute.

---
**Description:**
According to a conversation we had on Discord, the cache lasts for a minute, so updating more frequently is unnecessary.

---
**Fixes issue (include link):**
Not sure we need one.

---
**Mockups, screenshots, evidence:**


---

(Check one)
- [ ] Issue fix
- [x] Suggestion fulfillment
