### PR TITLE
Created SortiePanel

### DIFF
--- a/src/components/panels/SortiePanel.vue
+++ b/src/components/panels/SortiePanel.vue
@@ -1,0 +1,94 @@
+<template>
+  <b-col md="6">
+    <h3 class="text-center">{{headertext}}</h3>
+    <b-list-group>
+      <b-list-group-item :style="styleObject" class="list-group-item-borderless no-padding-bot">
+        <span class="pull-left">
+          <h4>
+            <HubImg :src="factionImg" :name="sortie.faction" :style="missionType" />
+            {{sortie.boss}}
+          </h4>
+        </span>
+        <TimeBadge :starttime="now" :endtime="sortie.expiry" :interval="1000"/>
+      </b-list-group-item>
+      <b-list-group-item :style="styleObject" v-for="(mission, index) in sortie.variants" :key="`sortie-${index}`" class="list-group-item-borderless">
+        <div class="indent-1">
+          <span class="pull-left">
+            <b>{{mission.missionType}} - {{mission.node}}</b>
+          </span>
+          <br />
+          <span v-b-tooltip.right :title="mission.modifierDescription" class="pull-left">
+            {{mission.modifier}}
+          </span>
+        </div>
+      </b-list-group-item>
+      <b-list-group-item class="list-group-item-borderbottom"></b-list-group-item>
+    </b-list-group>
+  </b-col>
+</template>
+<style scoped>
+  .no-padding-bot {
+    padding-bottom: 0px;
+  }
+
+  .indent-1 {
+    margin-left: 40px;
+  }
+</style>
+<script>
+  import HubImg from '@/components/HubImg.vue';
+  import TimeBadge from '@/components/TimeBadge.vue';
+  import moment from 'moment';
+  
+  import corpus from '@/assets/img/factions/corpus.svg';
+  import corrupted from '@/assets/img/factions/corrupted.svg';
+  import grineer from '@/assets/img/factions/grineer.svg';
+  import infested from '@/assets/img/factions/infested.svg';
+  import sentient from '@/assets/img/factions/sentient.svg';
+
+  export default {
+    props: ['sortie'],
+    name: 'SortiePanel',
+    computed: {
+      sortietimezonetime() {
+        return moment(this.$props.sortie.expiry).format('llll');
+      },
+      now() {
+        return moment().toISOString();
+      },
+      headertext() {
+        return 'Sortie';
+      },
+      factionImg() {
+        var fImg = {
+          corpus: corpus,
+          grineer: grineer,
+          infested: infested,
+          infestation: infested,
+          corrupted: corrupted,
+          orokin: corrupted,
+          sentient: sentient
+        };
+        return fImg[this.$props.sortie.faction.toLowerCase()] || corrupted;
+      }
+    },
+    components: {
+      TimeBadge,
+      HubImg
+    },
+    data() {
+      return {
+        styleObject: {
+          display: 'inline'
+        },
+        missionType: {
+          'filter': 'invert(100%)',
+          'margin-top': '-3px',
+          'margin-right': '5px',
+          'width': '25px',
+          'height': '25px',
+        }
+      };
+    }
+  };
+</script>

--- a/src/views/Timer.vue
+++ b/src/views/Timer.vue
@@ -8,6 +8,7 @@
         <TimePanel v-if="this.$store.getters.componentState.cetus.state" :time="this.$store.getters.worldstate.cetusCycle" location="Cetus" />
         <TimePanel v-if="this.$store.getters.componentState.vallis.state" :time="this.$store.getters.worldstate.vallisCycle" location="Vallis" />
         <ResetPanel />
+        <SortiePanel v-if="this.$store.getters.componentState.sortie.state" :sortie="this.$store.getters.worldstate.sortie"/>
       </b-row>
     </b-container>
   </div>
@@ -18,6 +19,7 @@ import AlertPanel from '@/components/panels/AlertPanel.vue';
 import NewsPanel from '@/components/panels/NewsPanel.vue';
 import TimePanel from '@/components/panels/TimePanel.vue';
 import ResetPanel from '@/components/panels/ResetPanel.vue';
+import SortiePanel from '@/components/panels/SortiePanel.vue';
 
 export default {
   name: 'timers',
@@ -25,7 +27,8 @@ export default {
     AlertPanel,
     NewsPanel,
     TimePanel,
-    ResetPanel
+    ResetPanel,
+    SortiePanel
   },
   methods: {
     track () {


### PR DESCRIPTION
### Warframe Hub Pull Request
---
**Summary (short):**
Created the file SortiePanel and added it to the Timer view.

---
**Description:**
I updated the sortie panel to vue.js such that it displays the boss name, boss faction, the list of missions, and for each mission: the node, type, and effect. Every effect also has a tooltip saying what it does. I added the sortie panel to the end of the Time view.

---
**Fixes issue (include link):**
closes #189 

---
**Mockups, screenshots, evidence:**
![image](https://user-images.githubusercontent.com/18157392/48805518-2eafc980-ecdd-11e8-84f9-696ce5666861.png)


---

(Check one)
- [x] Issue fix
- [x] Suggestion fulfillment
