### PR TITLE
Fix reset ignoring settings

### DIFF
--- a/src/views/Timer.vue
+++ b/src/views/Timer.vue
@@ -7,7 +7,7 @@
         <TimePanel v-if="this.$store.getters.componentState.earth.state" :time="this.$store.getters.worldstate.earthCycle" location="Earth" />
         <TimePanel v-if="this.$store.getters.componentState.cetus.state" :time="this.$store.getters.worldstate.cetusCycle" location="Cetus" />
         <TimePanel v-if="this.$store.getters.componentState.vallis.state" :time="this.$store.getters.worldstate.vallisCycle" location="Vallis" />
-        <ResetPanel />
+        <ResetPanel v-if="this.$store.getters.componentState.reset.state" />
         <SortiePanel v-if="this.$store.getters.componentState.sortie.state" :sortie="this.$store.getters.worldstate.sortie"/>
       </b-row>
     </b-container>


### PR DESCRIPTION
### Warframe Hub Pull Request
---
**Summary (short):**
The reset panel currently ignores the checkbox in the settings menu. This small patch fixes that.

---
**Fixes issue (include link):**
https://github.com/WFCD/warframe-hub/issues/214

---
**Mockups, screenshots, evidence:**
No reset panel:
![image](https://user-images.githubusercontent.com/18157392/48813198-7a716b80-ecfb-11e8-827f-6bdc7aee8f50.png)


---

(Check one)
- [x] Issue fix
- [ ] Suggestion fulfillment
