### PR TITLE
Fix Vallis component's display strings

### DIFF
--- a/assets/js/updaters.js
+++ b/assets/js/updaters.js
@@ -248,8 +248,8 @@ function updateVallisCycle() {
     cycleIndicator.addClass('pull-right');
   }
 
-  $('#valliscycletitle').html(cetusCurrentTitle);
-  $('#vallistimezonetitle').html(cetusCurrentTitleTimezone);
+  $('#valliscycletitle').html(vallisCurrentTitle);
+  $('#vallistimezonetitle').html(vallisCurrentTitleTimezone);
   $('#vallistimezonetime').html(moment.unix(expiryTime).format('llll'));
 
   const timeBadge = $('#valliscycletime');


### PR DESCRIPTION
Closes #224.

### Fix Vallis component's display strings
---
**Summary (short):**
We defined some variables for the correct strings, but stuck the wrong variables into `$.html`.

---
**Description:**
See #224

---
**Fixes issue (include link):**
#224

---
**Mockups, screenshots, evidence:**


---

(Check one)
- [x] Issue fix
- [ ] Suggestion fulfillment
