### PR TITLE
Fixed panel props being undefined on first load.

### DIFF
--- a/.example.env
+++ b/.example.env
@@ -1,1 +1,5 @@
 VUE_APP_DSN=https://6d5dcb1d6c764a748199e260bdd17e21@sentry.warframestat.us/#
+# Save store to localstorage
+VUE_APP_PERSIST=true
+# worldstate update interval
+VUE_APP_INTERVAL=30000

--- a/initialWorldstateUpdater.js
+++ b/initialWorldstateUpdater.js
@@ -1,0 +1,113 @@
+const fetch = require('node-fetch');
+const fs = require('fs');
+
+const jsonFileName = "initialWorldstate.json";
+const jsonFolder = "./src/assets/json";
+const apiBaseUrl = "api.warframestat.us";
+const apiPlatforms = [
+  "pc",
+  "ps4",
+  "xb1",
+  "swi"
+];
+
+
+function main() {
+  Promise.all(apiPlatforms.map((platform) => {
+    return fetch(`https://${apiBaseUrl}/${platform}`)
+      .then(t => t.text())
+      .then(JSON.parse)
+      .then(parseBase.bind(null, platform))
+      .catch(onError);
+  })).then((platformsData) => {
+    const output = platformsData.reduce((acc, data) => {
+      acc[data[0]] = data[1];
+      return acc;
+    }, {});
+    fs.writeFile(
+      `${jsonFolder}/${jsonFileName}`,
+      JSON.stringify(output, null, 2),
+      function(err) {
+        if(err) {
+          return console.log(err);
+        }
+        console.info();
+        console.info(`${jsonFileName} updated at ${jsonFolder}/${jsonFileName}`);
+      }
+    );
+  });
+}
+
+function onError(error) {
+  console.error(error);
+}
+
+function parseBase(platform, data) {
+  const platformOutput = parseObject(data, platform, platform);
+  return [platform, platformOutput];
+}
+
+function parseObject(data, key, objectPath = "") {
+  if (typeof(data) !== 'object') {
+    return null;
+  }
+
+  const orderedParseFunctions = [
+    parseArray,
+    parseObject,
+    parseBoolean,
+    parseDate,
+    parseId,
+    parseNumber,
+    parseETA,
+    parseDefault
+  ];
+  const cleanedData = {};
+
+  Object.entries(data).forEach(([key, prop]) => {
+    let temp;
+    for (let fun of orderedParseFunctions) {
+      temp = fun(prop, key, `${objectPath}.${key}`);
+      if (temp !== null) {
+        break;
+      }
+    }
+    cleanedData[key] = temp;
+  });
+
+  return cleanedData;
+}
+
+function parseArray(data) {
+  return Array.isArray(data) ? [] : null;
+}
+
+function parseBoolean(data, key) {
+  if (typeof(data) !== 'boolean') return null;
+
+  return key.toLowerCase().includes('expired');
+}
+
+function parseDate(data) {
+  return !isNaN(new Date(data)) ? "2000-01-01T01:00:00.000Z" : null;
+}
+
+function parseId(data, key) {
+  return key.toLowerCase().includes('id') ? "12345" : null;
+}
+
+function parseNumber(data) {
+  return !isNaN(data) ? "0.00" : null;
+}
+
+function parseETA(data) {
+  return /([-\d]+y |)([-\d]+d |)([-\d]+h |)([-\d]+m |)[-\d]+s/.test(data) ? "1h 1m 1s" : null;
+}
+
+function parseDefault(data, key, objectPath) {
+  const defaultOutput = "Loading...";
+  console.info(`Defaulting ${objectPath} - ${data} to ${defaultOutput}`);
+  return defaultOutput;
+}
+
+main();

--- a/initialWorldstateUpdater.js
+++ b/initialWorldstateUpdater.js
@@ -1,21 +1,22 @@
+/* eslint-disable no-console */
 const fetch = require('node-fetch');
 const fs = require('fs');
 
-const jsonFileName = "initialWorldstate.json";
-const jsonFolder = "./src/assets/json";
-const apiBaseUrl = "api.warframestat.us";
+const jsonFileName = 'initialWorldstate.json';
+const jsonFolder = './src/assets/json';
+const apiBaseUrl = 'api.warframestat.us';
 const apiPlatforms = [
-  "pc",
-  "ps4",
-  "xb1",
-  "swi"
+  'pc',
+  'ps4',
+  'xb1',
+  'swi'
 ];
 
 
 function main() {
   Promise.all(apiPlatforms.map((platform) => {
     return fetch(`https://${apiBaseUrl}/${platform}`)
-      .then(t => t.text())
+      .then((t) => t.text())
       .then(JSON.parse)
       .then(parseBase.bind(null, platform))
       .catch(onError);
@@ -47,7 +48,7 @@ function parseBase(platform, data) {
   return [platform, platformOutput];
 }
 
-function parseObject(data, key, objectPath = "") {
+function parseObject(data, key, objectPath = '') {
   if (typeof(data) !== 'object') {
     return null;
   }
@@ -83,29 +84,32 @@ function parseArray(data) {
 }
 
 function parseBoolean(data, key) {
-  if (typeof(data) !== 'boolean') return null;
+  if (typeof(data) !== 'boolean') {
+     return null;
+  }
 
   return key.toLowerCase().includes('expired');
 }
 
 function parseDate(data) {
-  return !isNaN(new Date(data)) ? "2000-01-01T01:00:00.000Z" : null;
+  return !isNaN(new Date(data)) ? '2000-01-01T01:00:00.000Z' : null;
 }
 
 function parseId(data, key) {
-  return key.toLowerCase().includes('id') ? "12345" : null;
+  return key.toLowerCase().includes('id') ? '12345' : null;
 }
 
 function parseNumber(data) {
-  return !isNaN(data) ? "0.00" : null;
+  return !isNaN(data) ? '0.00' : null;
 }
 
 function parseETA(data) {
-  return /([-\d]+y |)([-\d]+d |)([-\d]+h |)([-\d]+m |)[-\d]+s/.test(data) ? "1h 1m 1s" : null;
+  //Matches the format 0s with optional dates up to 0y 0d 0h 0m 0s
+  return /([-\d]+y |)([-\d]+d |)([-\d]+h |)([-\d]+m |)[-\d]+s/.test(data) ? '1h 1m 1s' : null;
 }
 
 function parseDefault(data, key, objectPath) {
-  const defaultOutput = "Loading...";
+  const defaultOutput = 'Loading...';
   console.info(`Defaulting ${objectPath} - ${data} to ${defaultOutput}`);
   return defaultOutput;
 }

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "build": "vue-cli-service build",
     "lint": "vue-cli-service lint",
     "lint:raw": "npx lint .",
-    "postinstall": "if test \"$NODE_ENV\" = \"production\" ; then npm run build ; fi "
+    "postinstall": "if test \"$NODE_ENV\" = \"production\" ; then npm run build ; fi ",
+    "updateWorldstate": "node ./initialWorldstateUpdater.js"
   },
   "dependencies": {
     "@fortawesome/fontawesome-free": "^5.6.3",

--- a/src/assets/json/initialWorldstate.json
+++ b/src/assets/json/initialWorldstate.json
@@ -1,0 +1,326 @@
+{
+  "pc": {
+    "timestamp": "2000-01-01T01:00:00.000Z",
+    "news": [],
+    "events": [],
+    "alerts": [],
+    "sortie": {
+      "id": "12345",
+      "activation": "2000-01-01T01:00:00.000Z",
+      "startString": "1h 1m 1s",
+      "expiry": "2000-01-01T01:00:00.000Z",
+      "active": false,
+      "rewardPool": "Loading...",
+      "variants": [],
+      "boss": "Loading...",
+      "faction": "Loading...",
+      "expired": true,
+      "eta": "1h 1m 1s"
+    },
+    "syndicateMissions": [],
+    "fissures": [],
+    "globalUpgrades": [],
+    "flashSales": [],
+    "invasions": [],
+    "darkSectors": [],
+    "voidTrader": {
+      "id": "12345",
+      "activation": "2000-01-01T01:00:00.000Z",
+      "startString": "1h 1m 1s",
+      "expiry": "2000-01-01T01:00:00.000Z",
+      "active": false,
+      "character": "Loading...",
+      "location": "Loading...",
+      "inventory": [],
+      "psId": "12345",
+      "endString": "1h 1m 1s"
+    },
+    "dailyDeals": [],
+    "simaris": {
+      "target": "Loading...",
+      "isTargetActive": false,
+      "asString": "Loading..."
+    },
+    "conclaveChallenges": [],
+    "persistentEnemies": [],
+    "earthCycle": {
+      "id": "12345",
+      "expiry": "2000-01-01T01:00:00.000Z",
+      "isDay": false,
+      "timeLeft": "1h 1m 1s"
+    },
+    "cetusCycle": {
+      "id": "12345",
+      "expiry": "2000-01-01T01:00:00.000Z",
+      "isDay": false,
+      "timeLeft": "1h 1m 1s",
+      "isCetus": false,
+      "shortString": "Loading..."
+    },
+    "weeklyChallenges": {
+      "id": "12345",
+      "activation": "2000-01-01T01:00:00.000Z",
+      "startString": "1h 1m 1s",
+      "expiry": "2000-01-01T01:00:00.000Z",
+      "active": false,
+      "challenges": []
+    },
+    "constructionProgress": {
+      "id": "12345",
+      "fomorianProgress": "0.00",
+      "razorbackProgress": "2000-01-01T01:00:00.000Z",
+      "unknownProgress": "0.00"
+    },
+    "vallisCycle": {
+      "id": "12345",
+      "expiry": "2000-01-01T01:00:00.000Z",
+      "isWarm": false,
+      "timeLeft": "1h 1m 1s",
+      "shortString": "Loading..."
+    },
+    "twitter": []
+  },
+  "ps4": {
+    "timestamp": "2000-01-01T01:00:00.000Z",
+    "news": [],
+    "events": [],
+    "alerts": [],
+    "sortie": {
+      "id": "12345",
+      "activation": "2000-01-01T01:00:00.000Z",
+      "startString": "1h 1m 1s",
+      "expiry": "2000-01-01T01:00:00.000Z",
+      "active": false,
+      "rewardPool": "Loading...",
+      "variants": [],
+      "boss": "Loading...",
+      "faction": "Loading...",
+      "expired": true,
+      "eta": "1h 1m 1s"
+    },
+    "syndicateMissions": [],
+    "fissures": [],
+    "globalUpgrades": [],
+    "flashSales": [],
+    "invasions": [],
+    "darkSectors": [],
+    "voidTrader": {
+      "id": "12345",
+      "activation": "2000-01-01T01:00:00.000Z",
+      "startString": "1h 1m 1s",
+      "expiry": "2000-01-01T01:00:00.000Z",
+      "active": false,
+      "character": "Loading...",
+      "location": "Loading...",
+      "inventory": [],
+      "psId": "12345",
+      "endString": "1h 1m 1s"
+    },
+    "dailyDeals": [],
+    "simaris": {
+      "target": "Loading...",
+      "isTargetActive": false,
+      "asString": "Loading..."
+    },
+    "conclaveChallenges": [],
+    "persistentEnemies": [],
+    "earthCycle": {
+      "id": "12345",
+      "expiry": "2000-01-01T01:00:00.000Z",
+      "isDay": false,
+      "timeLeft": "1h 1m 1s"
+    },
+    "cetusCycle": {
+      "id": "12345",
+      "expiry": "2000-01-01T01:00:00.000Z",
+      "isDay": false,
+      "timeLeft": "1h 1m 1s",
+      "isCetus": false,
+      "shortString": "Loading..."
+    },
+    "weeklyChallenges": {
+      "id": "12345",
+      "activation": "2000-01-01T01:00:00.000Z",
+      "startString": "1h 1m 1s",
+      "expiry": "2000-01-01T01:00:00.000Z",
+      "active": false,
+      "challenges": []
+    },
+    "constructionProgress": {
+      "id": "12345",
+      "fomorianProgress": "2000-01-01T01:00:00.000Z",
+      "razorbackProgress": "0.00",
+      "unknownProgress": "0.00"
+    },
+    "vallisCycle": {
+      "id": "12345",
+      "expiry": "2000-01-01T01:00:00.000Z",
+      "isWarm": false,
+      "timeLeft": "1h 1m 1s",
+      "shortString": "Loading..."
+    },
+    "twitter": []
+  },
+  "xb1": {
+    "timestamp": "2000-01-01T01:00:00.000Z",
+    "news": [],
+    "events": [],
+    "alerts": [],
+    "sortie": {
+      "id": "12345",
+      "activation": "2000-01-01T01:00:00.000Z",
+      "startString": "1h 1m 1s",
+      "expiry": "2000-01-01T01:00:00.000Z",
+      "active": false,
+      "rewardPool": "Loading...",
+      "variants": [],
+      "boss": "Loading...",
+      "faction": "Loading...",
+      "expired": true,
+      "eta": "1h 1m 1s"
+    },
+    "syndicateMissions": [],
+    "fissures": [],
+    "globalUpgrades": [],
+    "flashSales": [],
+    "invasions": [],
+    "darkSectors": [],
+    "voidTrader": {
+      "id": "12345",
+      "activation": "2000-01-01T01:00:00.000Z",
+      "startString": "1h 1m 1s",
+      "expiry": "2000-01-01T01:00:00.000Z",
+      "active": false,
+      "character": "Loading...",
+      "location": "Loading...",
+      "inventory": [],
+      "psId": "12345",
+      "endString": "1h 1m 1s"
+    },
+    "dailyDeals": [],
+    "simaris": {
+      "target": "Loading...",
+      "isTargetActive": false,
+      "asString": "Loading..."
+    },
+    "conclaveChallenges": [],
+    "persistentEnemies": [],
+    "earthCycle": {
+      "id": "12345",
+      "expiry": "2000-01-01T01:00:00.000Z",
+      "isDay": false,
+      "timeLeft": "1h 1m 1s"
+    },
+    "cetusCycle": {
+      "id": "12345",
+      "expiry": "2000-01-01T01:00:00.000Z",
+      "isDay": false,
+      "timeLeft": "1h 1m 1s",
+      "isCetus": false,
+      "shortString": "Loading..."
+    },
+    "weeklyChallenges": {
+      "id": "12345",
+      "activation": "2000-01-01T01:00:00.000Z",
+      "startString": "1h 1m 1s",
+      "expiry": "2000-01-01T01:00:00.000Z",
+      "active": false,
+      "challenges": []
+    },
+    "constructionProgress": {
+      "id": "12345",
+      "fomorianProgress": "0.00",
+      "razorbackProgress": "0.00",
+      "unknownProgress": "0.00"
+    },
+    "vallisCycle": {
+      "id": "12345",
+      "expiry": "2000-01-01T01:00:00.000Z",
+      "isWarm": false,
+      "timeLeft": "1h 1m 1s",
+      "shortString": "Loading..."
+    },
+    "twitter": []
+  },
+  "swi": {
+    "timestamp": "2000-01-01T01:00:00.000Z",
+    "news": [],
+    "events": [],
+    "alerts": [],
+    "sortie": {
+      "id": "12345",
+      "activation": "2000-01-01T01:00:00.000Z",
+      "startString": "1h 1m 1s",
+      "expiry": "2000-01-01T01:00:00.000Z",
+      "active": false,
+      "rewardPool": "Loading...",
+      "variants": [],
+      "boss": "Loading...",
+      "faction": "Loading...",
+      "expired": true,
+      "eta": "1h 1m 1s"
+    },
+    "syndicateMissions": [],
+    "fissures": [],
+    "globalUpgrades": [],
+    "flashSales": [],
+    "invasions": [],
+    "darkSectors": [],
+    "voidTrader": {
+      "id": "12345",
+      "activation": "2000-01-01T01:00:00.000Z",
+      "startString": "1h 1m 1s",
+      "expiry": "2000-01-01T01:00:00.000Z",
+      "active": false,
+      "character": "Loading...",
+      "location": "Loading...",
+      "inventory": [],
+      "psId": "12345",
+      "endString": "1h 1m 1s"
+    },
+    "dailyDeals": [],
+    "simaris": {
+      "target": "Loading...",
+      "isTargetActive": false,
+      "asString": "Loading..."
+    },
+    "conclaveChallenges": [],
+    "persistentEnemies": [],
+    "earthCycle": {
+      "id": "12345",
+      "expiry": "2000-01-01T01:00:00.000Z",
+      "isDay": false,
+      "timeLeft": "1h 1m 1s"
+    },
+    "cetusCycle": {
+      "id": "12345",
+      "expiry": "2000-01-01T01:00:00.000Z",
+      "isDay": false,
+      "timeLeft": "1h 1m 1s",
+      "isCetus": false,
+      "shortString": "Loading..."
+    },
+    "weeklyChallenges": {
+      "id": "12345",
+      "activation": "2000-01-01T01:00:00.000Z",
+      "startString": "1h 1m 1s",
+      "expiry": "2000-01-01T01:00:00.000Z",
+      "active": false,
+      "challenges": []
+    },
+    "constructionProgress": {
+      "id": "12345",
+      "fomorianProgress": "2000-01-01T01:00:00.000Z",
+      "razorbackProgress": "0.00",
+      "unknownProgress": "0.00"
+    },
+    "vallisCycle": {
+      "id": "12345",
+      "expiry": "2000-01-01T01:00:00.000Z",
+      "isWarm": false,
+      "timeLeft": "1h 1m 1s",
+      "shortString": "Loading..."
+    },
+    "twitter": []
+  }
+}

--- a/src/store.js
+++ b/src/store.js
@@ -8,16 +8,17 @@ import grid from '@/assets/json/grid.json';
 import components from '@/assets/json/components.json';
 import trackables from '@/assets/json/trackables.json';
 import fissurePlanets from '@/assets/json/planets.json';
+import initialWorldstate from '@/assets/json/initialWorldstate.json';
 
 const apiBase = 'https://api.warframestat.us';
 let notifier;
 
 const state = {
   worldstates: {
-    pc: {},
-    ps4: {},
-    xb1: {},
-    switch: {}
+    pc: initialWorldstate.pc,
+    ps4: initialWorldstate.ps4,
+    xb1: initialWorldstate.xb1,
+    switch: initialWorldstate.swi
   },
   platform: 'pc',
   theme: 'night',


### PR DESCRIPTION
### Warframe Hub Pull Request
---
**Summary (short):**
Fixes issue where the vue panel render function would crash due to undefined props.

---
**Description:**
Due to worldstate not being cached in localstorage till after first load, during the first load there is a chance for a panel to crash due to missing prop data. This adds a JSON file containing default files for all props based on the data returned from api.warframestat.us/{platform} . Run `npm run updateWorldstate` to update these defaults.

---
**Fixes issue (include link):**


---
**Mockups, screenshots, evidence:**


---

(Check one)
- [x] Issue fix
- [ ] Suggestion fulfillment
