### PR TITLE
Collapse excess invasions, Fix #59

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -31,7 +31,7 @@ Use the provided `.eslintrc.json` to lint your files, include any ignores in you
 
 5. View logs in `pm2 logs warframe-hub` if you wish to see logs for the process.
 
-6. Check in your browser at http://localhost:3000 (by default) or whatever you changed the prot to.
+6. Check in your browser at http://localhost:3000 (by default) or whatever you changed the port to.
 
 ### Resources
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -35,7 +35,7 @@ Use the provided `.eslintrc.json` to lint your files, include any ignores in you
 
 ### Resources
 
-Nothin here yet
+Nothing here yet
 
 ## Contributors
 

--- a/src/assets/json/components.json
+++ b/src/assets/json/components.json
@@ -90,6 +90,7 @@
     "display": "Invasions",
     "key": "invasions",
     "component": "InvasionsPanel",
+    "expand":false,
     "props": {
       "invasions": "@worldstate.invasions"
     }

--- a/src/components/Collapsible.vue
+++ b/src/components/Collapsible.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <b-btn variant="primary" v-b-toggle="`collapsible-${this.cid}`">
+    <b-btn variant="primary" v-b-toggle="`collapsible-${this.cid}`" style="margin-bottom: 4px;">
       {{headertext}} <i class="fas fa-chevron-down"></i>
     </b-btn>
     <b-collapse :id="`collapsible-${this.cid}`" @hidden="reflow()" @shown="reflow()">

--- a/src/components/Invasion.vue
+++ b/src/components/Invasion.vue
@@ -1,0 +1,85 @@
+<template>
+  <div>
+  <div :id="`${invasion.id}_info`" class="text-center">
+    <span><b>{{invasion.node}}</b></span>
+    <b-btn :id="`${invasion.id}_tooltip`" class="pull-right" size="sm" variant="secondary">?</b-btn>
+    <b-tooltip :target="`${invasion.id}_tooltip`" placement="top">
+      &nbsp;
+      <TimeBadge :starttime="invasion.activation" :counter="true" :interval="1000"/>
+    </b-tooltip>
+    <br/>
+    {{invasion.desc}} {{eta(invasion)}}
+  </div>
+  <b-row>
+    <b-col>
+      <div class="pull-left">
+        <b-badge tag="div" v-for="item in invasion.attackerReward.items" :key="item" :variant="getLabelColor(invasion.attackingFaction)">{{item}}</b-badge>
+        <b-badge tag="div" v-for="item in invasion.attackerReward.countedItems" :key="item.type" :variant="getLabelColor(invasion.attackingFaction)">{{countedItem(item)}}</b-badge>
+      </div>
+      <div class="pull-right">
+        <b-badge v-for="item in invasion.defenderReward.items" :key="item" :variant="getLabelColor(invasion.defendingFaction)">{{item}}</b-badge>
+        <b-badge v-for="item in invasion.defenderReward.countedItems" :key="item.type" :variant="getLabelColor(invasion.defendingFaction)">{{countedItem(item)}}</b-badge>
+      </div>
+    </b-col>
+  </b-row>
+  <b-row>
+    <b-progress :max="100" class="w-100 h-125">
+      <b-progress-bar :variant="getLabelColor(invasion.attackingFaction)" :value="invasion.completion"></b-progress-bar>
+      <b-progress-bar :variant="getLabelColor(invasion.defendingFaction)" :value="100 - invasion.completion"></b-progress-bar>
+    </b-progress>
+  </b-row>
+  </div>
+</template>
+
+<script>
+  import TimeBadge from '@/components/TimeBadge.vue';
+
+  export default {
+    name: 'Invasion',
+    props: ['invasion'],
+    data () {
+      return {
+        styleObject: {
+          display: 'inline',
+        },
+      };
+    },
+    methods: {
+      eta: function(invasion) {
+        return `(Ends in: ${invasion.eta.replace('-Infinityd', '??').replace('Infinityd', '??').replace(/\s\d\d?s/ig, '')})*`;
+      },
+      getLabelColor: function(faction) {
+        switch (faction) {
+          case 'Corpus':
+            return 'info';
+          case 'Grineer':
+            return 'danger';
+          case 'Infested':
+            return 'success';
+          case 'Corrupted':
+            return 'warning';
+          default:
+            return 'default';
+        }
+      },
+      countedItem: function(item) {
+        if (item.count > 1) {
+          return `${item.count} ${item.type}`;
+        }
+        return item.type;
+      },
+      ongoing: function(invasions) {
+        var ongoingInvasions = [];
+        for (var i = 0; i < invasions.length; i++) {
+          if (!invasions[i].completed) {
+            ongoingInvasions.push(invasions[i]);
+          }
+        }
+        return ongoingInvasions;
+      }
+    },
+    components: {
+      TimeBadge,
+    }
+  };
+</script>

--- a/src/components/Spoiler.vue
+++ b/src/components/Spoiler.vue
@@ -1,10 +1,10 @@
 <template>
   <div>
-    <b-collapse :id="`collapsible-${this.cid}`" @hidden="reflow()" @shown="reflow()">
+    <b-collapse :id="`spoiler-${this.cid}`" @hidden="reflow();downArrow();" @shown="reflow();upArrow();">
       <slot></slot>
     </b-collapse>
-    <b-btn variant="primary" v-b-toggle="`collapsible-${this.cid}`" style="margin: 3px 0px;">
-      {{headertext}} <i class="fas fa-chevron-down"></i>
+    <b-btn variant="primary" v-b-toggle="`spoiler-${this.cid}`" style="margin: 3px 0px;">
+      {{headertext}} <i class="fas fa-chevron-down" ref="arrow"></i>
     </b-btn>
   </div>
 </template>
@@ -26,6 +26,12 @@
       },
       makeid: function() {
         return util.makeid();
+      },
+      upArrow: function() {
+        this.$refs.arrow.className='fas fa-chevron-up';
+      },
+      downArrow: function() {
+        this.$refs.arrow.className='fas fa-chevron-down';
       }
     },
     computed: {

--- a/src/components/Spoiler.vue
+++ b/src/components/Spoiler.vue
@@ -1,10 +1,10 @@
 <template>
   <div>
-    <b-collapse :id="`spoiler-${this.cid}`" @hidden="reflow();downArrow();" @shown="reflow();upArrow();">
+    <b-collapse :id="`spoiler-${this.cid}`" @hidden="toggled();downArrow();" @shown="toggled();upArrow();" v-bind:visible="init">
       <slot></slot>
     </b-collapse>
     <b-btn variant="primary" v-b-toggle="`spoiler-${this.cid}`" style="margin: 3px 0px;">
-      {{headertext}} <i class="fas fa-chevron-down" ref="arrow"></i>
+      {{headertext}} <i :class="this.initialArrow" ref="arrow"></i>
     </b-btn>
   </div>
 </template>
@@ -13,16 +13,15 @@
 
   export default {
     name: 'Collapsible',
-    props: ['headertext'],
+    props: ['headertext', 'init'],
     data: function() {
       return {
         id: 0
       };
     },
     methods: {
-      reflow: function() {
-        // eslint-disable-next-line no-console
-        console.error('triggered reflow --- this does nothing, needs to trigger the resize for the grid item');
+      toggled: function() {
+        this.$emit('toggle');
       },
       makeid: function() {
         return util.makeid();
@@ -42,6 +41,12 @@
           this.id = this.makeid(); // eslint-disable-line vue/no-side-effects-in-computed-properties
         }
         return this.id;
+      },
+      initialArrow: function() {
+        if (this.init) {
+          return 'fas fa-chevron-up';
+        }
+        return 'fas fa-chevron-down';
       }
     }
   };

--- a/src/components/Spoiler.vue
+++ b/src/components/Spoiler.vue
@@ -3,7 +3,7 @@
     <b-collapse :id="`collapsible-${this.cid}`" @hidden="reflow()" @shown="reflow()">
       <slot></slot>
     </b-collapse>
-    <b-btn variant="primary" v-b-toggle="`collapsible-${this.cid}`">
+    <b-btn variant="primary" v-b-toggle="`collapsible-${this.cid}`" style="margin: 3px 0px;">
       {{headertext}} <i class="fas fa-chevron-down"></i>
     </b-btn>
   </div>

--- a/src/components/Spoiler.vue
+++ b/src/components/Spoiler.vue
@@ -1,0 +1,42 @@
+<template>
+  <div>
+    <b-collapse :id="`collapsible-${this.cid}`" @hidden="reflow()" @shown="reflow()">
+      <slot></slot>
+    </b-collapse>
+    <b-btn variant="primary" v-b-toggle="`collapsible-${this.cid}`">
+      {{headertext}} <i class="fas fa-chevron-down"></i>
+    </b-btn>
+  </div>
+</template>
+<script>
+  import util from '@/utilities';
+
+  export default {
+    name: 'Collapsible',
+    props: ['headertext'],
+    data: function() {
+      return {
+        id: 0
+      };
+    },
+    methods: {
+      reflow: function() {
+        // eslint-disable-next-line no-console
+        console.error('triggered reflow --- this does nothing, needs to trigger the resize for the grid item');
+      },
+      makeid: function() {
+        return util.makeid();
+      }
+    },
+    computed: {
+      cid: function() {
+        if (this.id) {
+          return this.id;
+        } else {
+          this.id = this.makeid(); // eslint-disable-line vue/no-side-effects-in-computed-properties
+        }
+        return this.id;
+      }
+    }
+  };
+</script>

--- a/src/components/panels/InvasionsPanel.vue
+++ b/src/components/panels/InvasionsPanel.vue
@@ -41,7 +41,8 @@
         return 5;
       },
       initialStatus() {
-        return this.$store.getters.expandInvasions;
+        var state = this.$store.getters.componentState['invasions'];
+        return state.expand;
       }
     },
     data () {
@@ -62,8 +63,11 @@
         return ongoingInvasions;
       },
       updatePanelStatus: function() {
-        var currentStatus = this.$store.getters.expandInvasions;
-        this.$store.commit('commitExpandInvasions', !currentStatus);
+        var state = this.$store.getters.componentState['invasions'];
+        state.expand= !state.expand;
+        // eslint-disable-next-line no-console
+        console.log(state);
+        this.$store.commit('commitComponent', ['invasions', state]);
       }
     },
     components: {

--- a/src/components/panels/InvasionsPanel.vue
+++ b/src/components/panels/InvasionsPanel.vue
@@ -38,7 +38,7 @@
         return 'Invasions';
       },
       maxInvasions() {
-        return 5
+        return 5;
       }
     },
     data () {

--- a/src/components/panels/InvasionsPanel.vue
+++ b/src/components/panels/InvasionsPanel.vue
@@ -7,8 +7,8 @@
         'list-group-item-borderbottom': index === (ongoing(invasions).length - 1) }">
         <Invasion :invasion="invasion"></Invasion>
       </b-list-group-item>
-      <b-list-group-item class="list-group-item-borderbottom" v-if="ongoing(invasions).length>2">
-        <Collapsible :headertext="`Show More (${ongoing(invasions).length-maxInvasions})`">
+      <b-list-group-item class="list-group-item-borderbottom" v-if="ongoing(invasions).length>maxInvasions" style="padding:0;">
+        <Spoiler>
           <b-list-group>
             <b-list-group-item :style="styleObject" v-for="(invasion, index) in ongoing(invasions).splice(maxInvasions)" :key="invasion.id"
               v-bind:class="{
@@ -17,7 +17,7 @@
                 <Invasion :invasion="invasion"></Invasion>
             </b-list-group-item>
           </b-list-group>
-        </Collapsible>
+        </Spoiler>
       </b-list-group-item>
       <NoDataItem v-if="invasions.length === 0" :text="headertext" />
     </b-list-group>
@@ -27,7 +27,7 @@
 <script>
   import NoDataItem from '@/components/NoDataItem.vue';
   import HubPanelWrap from '@/components/HubPanelWrap';
-  import Collapsible from '@/components/Collapsible';
+  import Spoiler from '@/components/Spoiler';
   import Invasion from '@/components/Invasion';
 
   export default {
@@ -61,7 +61,7 @@
     },
     components: {
       Invasion,
-      Collapsible,
+      Spoiler,
       NoDataItem,
       HubPanelWrap,
     }

--- a/src/components/panels/InvasionsPanel.vue
+++ b/src/components/panels/InvasionsPanel.vue
@@ -1,40 +1,23 @@
 <template>
   <HubPanelWrap :title="headertext">
     <b-list-group>
-      <b-list-group-item :style="styleObject" v-for="(invasion, index) in invasions" :key="invasion.id"
+      <b-list-group-item :style="styleObject" v-for="(invasion, index) in ongoing(invasions).splice(0,maxInvasions)" :key="invasion.id"
       v-bind:class="{
-        'list-group-item-borderless': index < (invasions.length - 1),
-        'list-group-item-borderbottom': index === (invasions.length - 1) }"
-        v-if="!invasion.completed">
-
-        <div :id="`${invasion.id}_info`" class="text-center">
-          <span><b>{{invasion.node}}</b></span>
-          <b-btn :id="`${invasion.id}_tooltip`" class="pull-right" size="sm" variant="secondary">?</b-btn>
-          <b-tooltip :target="`${invasion.id}_tooltip`" placement="top">
-            &nbsp;
-            <TimeBadge :starttime="invasion.activation" :counter="true" :interval="1000"/>
-          </b-tooltip>
-          <br/>
-          {{invasion.desc}} {{eta(invasion)}}
-        </div>
-        <b-row>
-          <b-col>
-            <div class="pull-left">
-              <b-badge tag="div" v-for="item in invasion.attackerReward.items" :key="item" :variant="getLabelColor(invasion.attackingFaction)">{{item}}</b-badge>
-              <b-badge tag="div" v-for="item in invasion.attackerReward.countedItems" :key="item.type" :variant="getLabelColor(invasion.attackingFaction)">{{countedItem(item)}}</b-badge>
-            </div>
-            <div class="pull-right">
-              <b-badge v-for="item in invasion.defenderReward.items" :key="item" :variant="getLabelColor(invasion.defendingFaction)">{{item}}</b-badge>
-              <b-badge v-for="item in invasion.defenderReward.countedItems" :key="item.type" :variant="getLabelColor(invasion.defendingFaction)">{{countedItem(item)}}</b-badge>
-            </div>
-          </b-col>
-        </b-row>
-        <b-row>
-          <b-progress :max="100" class="w-100 h-125">
-            <b-progress-bar :variant="getLabelColor(invasion.attackingFaction)" :value="invasion.completion"></b-progress-bar>
-            <b-progress-bar :variant="getLabelColor(invasion.defendingFaction)" :value="100 - invasion.completion"></b-progress-bar>
-          </b-progress>
-        </b-row>
+        'list-group-item-borderless': index < (ongoing(invasions).length - 1),
+        'list-group-item-borderbottom': index === (ongoing(invasions).length - 1) }">
+        <Invasion :invasion="invasion"></Invasion>
+      </b-list-group-item>
+      <b-list-group-item class="list-group-item-borderbottom" v-if="ongoing(invasions).length>2">
+        <Collapsible :headertext="`Show More (${ongoing(invasions).length-maxInvasions})`">
+          <b-list-group>
+            <b-list-group-item :style="styleObject" v-for="(invasion, index) in ongoing(invasions).splice(maxInvasions)" :key="invasion.id"
+              v-bind:class="{
+                'list-group-item-borderless': index < (ongoing(invasions).length - 1),
+                'list-group-item-borderbottom': index === (ongoing(invasions).length - 1) }">
+                <Invasion :invasion="invasion"></Invasion>
+            </b-list-group-item>
+          </b-list-group>
+        </Collapsible>
       </b-list-group-item>
       <NoDataItem v-if="invasions.length === 0" :text="headertext" />
     </b-list-group>
@@ -42,9 +25,10 @@
 </template>
 
 <script>
-  import TimeBadge from '@/components/TimeBadge.vue';
   import NoDataItem from '@/components/NoDataItem.vue';
   import HubPanelWrap from '@/components/HubPanelWrap';
+  import Collapsible from '@/components/Collapsible';
+  import Invasion from '@/components/Invasion';
 
   export default {
     name: 'InvasionsPanel',
@@ -53,6 +37,9 @@
       headertext() {
         return 'Invasions';
       },
+      maxInvasions() {
+        return 5
+      }
     },
     data () {
       return {
@@ -62,32 +49,19 @@
       };
     },
     methods: {
-      eta: function(invasion) {
-        return `(Ends in: ${invasion.eta.replace('-Infinityd', '??').replace('Infinityd', '??').replace(/\s\d\d?s/ig, '')})*`;
-      },
-      getLabelColor: function(faction) {
-        switch (faction) {
-          case 'Corpus':
-            return 'info';
-          case 'Grineer':
-            return 'danger';
-          case 'Infested':
-            return 'success';
-          case 'Corrupted':
-            return 'warning';
-          default:
-            return 'default';
+      ongoing: function(invasions) {
+        var ongoingInvasions = [];
+        for (var i = 0; i < invasions.length; i++) {
+          if (!invasions[i].completed) {
+            ongoingInvasions.push(invasions[i]);
+          }
         }
-      },
-      countedItem: function(item) {
-        if (item.count > 1) {
-          return `${item.count} ${item.type}`;
-        }
-        return item.type;
-      },
+        return ongoingInvasions;
+      }
     },
     components: {
-      TimeBadge,
+      Invasion,
+      Collapsible,
       NoDataItem,
       HubPanelWrap,
     }

--- a/src/components/panels/InvasionsPanel.vue
+++ b/src/components/panels/InvasionsPanel.vue
@@ -41,7 +41,7 @@
         return 5;
       },
       initialStatus() {
-        var state = this.$store.getters.componentState['invasions'];
+        var state = this.$store.getters.componentState.invasions;
         return state.expand;
       }
     },
@@ -64,9 +64,7 @@
       },
       updatePanelStatus: function() {
         var state = this.$store.getters.componentState['invasions'];
-        state.expand= !state.expand;
-        // eslint-disable-next-line no-console
-        console.log(state);
+        state.expand = !state.expand;
         this.$store.commit('commitComponent', ['invasions', state]);
       }
     },

--- a/src/components/panels/InvasionsPanel.vue
+++ b/src/components/panels/InvasionsPanel.vue
@@ -8,7 +8,7 @@
         <Invasion :invasion="invasion"></Invasion>
       </b-list-group-item>
       <b-list-group-item class="list-group-item-borderbottom" v-if="ongoing(invasions).length>maxInvasions" style="padding:0;">
-        <Spoiler>
+        <Spoiler :init="initialStatus" @toggle='updatePanelStatus()'>
           <b-list-group>
             <b-list-group-item :style="styleObject" v-for="(invasion, index) in ongoing(invasions).splice(maxInvasions)" :key="invasion.id"
               v-bind:class="{
@@ -38,7 +38,10 @@
         return 'Invasions';
       },
       maxInvasions() {
-        return 5;
+        return 2;
+      },
+      initialStatus() {
+        return this.$store.getters.expandInvasions;
       }
     },
     data () {
@@ -57,6 +60,10 @@
           }
         }
         return ongoingInvasions;
+      },
+      updatePanelStatus: function() {
+        var currentStatus = this.$store.getters.expandInvasions;
+        this.$store.commit('commitExpandInvasions', !currentStatus);
       }
     },
     components: {

--- a/src/components/panels/InvasionsPanel.vue
+++ b/src/components/panels/InvasionsPanel.vue
@@ -38,7 +38,7 @@
         return 'Invasions';
       },
       maxInvasions() {
-        return 2;
+        return 5;
       },
       initialStatus() {
         return this.$store.getters.expandInvasions;

--- a/src/store.js
+++ b/src/store.js
@@ -34,7 +34,6 @@ const state = {
     xb1: [],
     switch: [],
   },
-  expandInvasions: false
 };
 const mutations = {
   commitWs: (state, [platform, worldstate]) => {
@@ -73,8 +72,8 @@ const mutations = {
   notifiedIds: (state, [notifiedIds, platform]) => {
     state.notifiedIds[platform || state.platform] = notifiedIds;
   },
-  commitExpandInvasions: (state, expandInvasions) => {
-    state.expandInvasions = expandInvasions;
+  commitComponent: (state, [key, newState]) => {
+    state.components[key] = newState;
   }
 };
 const actions = {
@@ -147,7 +146,6 @@ const getters = {
   sounds: (state) => state.soundFilters,
   notificationAllowance: (state) => state.notificationsAllowed,
   notifiedIds: (state) => state.notifiedIds[state.platform],
-  expandInvasions: (state) => state.expandInvasions,
 };
 
 Vue.use(Vuex);

--- a/src/store.js
+++ b/src/store.js
@@ -33,7 +33,8 @@ const state = {
     ps4: [],
     xb1: [],
     switch: [],
-  }
+  },
+  expandInvasions: false
 };
 const mutations = {
   commitWs: (state, [platform, worldstate]) => {
@@ -71,6 +72,9 @@ const mutations = {
   },
   notifiedIds: (state, [notifiedIds, platform]) => {
     state.notifiedIds[platform || state.platform] = notifiedIds;
+  },
+  commitExpandInvasions: (state, expandInvasions) => {
+    state.expandInvasions = expandInvasions;
   }
 };
 const actions = {
@@ -143,6 +147,7 @@ const getters = {
   sounds: (state) => state.soundFilters,
   notificationAllowance: (state) => state.notificationsAllowed,
   notifiedIds: (state) => state.notifiedIds[state.platform],
+  expandInvasions: (state) => state.expandInvasions,
 };
 
 Vue.use(Vuex);


### PR DESCRIPTION
### Warframe Hub Pull Request
---
**Summary (short):**
This pull request aims to fix issue collapse excess invasions on the invasions panel.

---
**Description:**
It adds a button on the Invasions panel when there are more than 5 active invasions. Clicking on it will expand the remaining invasions.

It uses the 'Collapsible' component.

I also moved everything related to a single Invasion to a separate component in order to keep the code relatively simple.

---
**Fixes issue (include link):**
#59 

---
**Mockups, screenshots, evidence:**

Collapsed:

![image](https://user-images.githubusercontent.com/51477716/59161916-f3de7900-8ae8-11e9-918b-53e59c3de36e.png)

Expanded:
 
![image](https://user-images.githubusercontent.com/51477716/59161929-17a1bf00-8ae9-11e9-861f-bbfdf41a3d86.png)


---

(Check one)
- [x] Issue fix
- [ ] Suggestion fulfillment
