### PR TITLE
News Refactor pt2

### DIFF
--- a/src/assets/json/components.json
+++ b/src/assets/json/components.json
@@ -83,7 +83,8 @@
     "component": "NewsPanel",
     "props": {
       "news": "@worldstate.news"
-    }
+    },
+    "autoCycle": true
   },
   "invasions": {
     "state": true,

--- a/src/store.js
+++ b/src/store.js
@@ -71,6 +71,9 @@ const mutations = {
   },
   notifiedIds: (state, [notifiedIds, platform]) => {
     state.notifiedIds[platform || state.platform] = notifiedIds;
+  },
+  autoProgressNews: (state, [newState]) => {
+    state.components.news.autoCycle = newState;
   }
 };
 const actions = {


### PR DESCRIPTION
### Warframe Hub Pull Request
---
**Summary (short):**
Hover, but if auto-progress is on, it takes priority.
Auto-progress is refresh persistent and toggleable.

---
**Description:**
Add a toggleable to turn automatic cycling of news items on/off, defaults on
If you turn it on after it's been off and you've hovered over something, it `null`s out the current hover
Hovering over a news item also sets the image to the corresponding news item
Mouseout doesn't null out the hover, so it stays persistent if you mouse out of the component


---
**Fixes issue (include link):**
closes #293 
