### PR TITLE
Change component attribute name 'state' to 'display', Fix #318

### DIFF
--- a/src/assets/json/components.json
+++ b/src/assets/json/components.json
@@ -1,7 +1,7 @@
 {
   "event": {
     "display": true,
-    "display_name": "Events",
+    "displayName": "Events",
     "key": "event",
     "component": "EventsPanel",
     "props": {
@@ -10,7 +10,7 @@
   },
   "acolytes": {
     "display": true,
-    "display_name": "Acolytes",
+    "displayName": "Acolytes",
     "key": "acolytes",
     "component": "AcolytesPanel",
     "props": {
@@ -19,7 +19,7 @@
   },
   "cetus": {
     "display": true,
-    "display_name": "Cetus Cycle",
+    "displayName": "Cetus Cycle",
     "key": "cetus",
     "component": "TimePanel",
     "props": {
@@ -29,7 +29,7 @@
   },
   "earth": {
     "display": true,
-    "display_name": "Earth Cycle",
+    "displayName": "Earth Cycle",
     "key": "earth",
     "component": "TimePanel",
     "props": {
@@ -39,7 +39,7 @@
   },
   "vallis": {
     "display": true,
-    "display_name": "Vallis Cycle",
+    "displayName": "Vallis Cycle",
     "key": "vallis",
     "component": "TimePanel",
     "props": {
@@ -49,7 +49,7 @@
   },
   "bounties": {
     "display": true,
-    "display_name": "Bounties Timer",
+    "displayName": "Bounties Timer",
     "key": "bounties",
     "component": "BountyPanel",
     "props": {
@@ -59,7 +59,7 @@
   },
   "solaris-bounties": {
     "display": true,
-    "display_name": "Solaris Bounties Timer",
+    "displayName": "Solaris Bounties Timer",
     "key": "solaris-bounties",
     "component": "BountyPanel",
     "props": {
@@ -69,7 +69,7 @@
   },
   "alerts": {
     "display": true,
-    "display_name": "Alerts",
+    "displayName": "Alerts",
     "key": "alerts",
     "component": "AlertPanel",
     "props": {
@@ -78,7 +78,7 @@
   },
   "news": {
     "display": true,
-    "display_name": "News",
+    "displayName": "News",
     "key": "news",
     "component": "NewsPanel",
     "props": {
@@ -87,7 +87,7 @@
   },
   "invasions": {
     "display": true,
-    "display_name": "Invasions",
+    "displayName": "Invasions",
     "key": "invasions",
     "component": "InvasionsPanel",
     "expand":false,
@@ -97,14 +97,14 @@
   },
   "reset": {
     "display": true,
-    "display_name": "Reset Timer",
+    "displayName": "Reset Timer",
     "key": "reset",
     "component": "ResetPanel",
     "props": {}
   },
   "sortie": {
     "display": true,
-    "display_name": "Sortie",
+    "displayName": "Sortie",
     "key": "sortie",
     "component": "SortiePanel",
     "props": {
@@ -113,7 +113,7 @@
   },
   "fissures": {
     "display": true,
-    "display_name": "Fissures",
+    "displayName": "Fissures",
     "key": "fissures",
     "component": "FissuresPanel",
     "props": {
@@ -122,7 +122,7 @@
   },
   "baro": {
     "display": true,
-    "display_name": "Void Trader",
+    "displayName": "Void Trader",
     "key": "baro",
     "component": "VoidTraderPanel",
     "props": {
@@ -131,7 +131,7 @@
   },
   "darvo": {
     "display": true,
-    "display_name": "Darvo Deals",
+    "displayName": "Darvo Deals",
     "key": "darvo",
     "component": "DarvoDealsPanel",
     "props": {
@@ -140,7 +140,7 @@
   },
   "deals": {
     "display": false,
-    "display_name": "Sales",
+    "displayName": "Sales",
     "key": "deals",
     "component": "SalesPanel",
     "props": {
@@ -149,7 +149,7 @@
   },
   "nightwave": {
     "display": true,
-    "display_name": "Nightwave",
+    "displayName": "Nightwave",
     "key": "nightwave",
     "component": "NightwavePanel",
     "props": {

--- a/src/assets/json/components.json
+++ b/src/assets/json/components.json
@@ -1,7 +1,7 @@
 {
   "event": {
-    "state": true,
-    "display": "Events",
+    "display": true,
+    "display_name": "Events",
     "key": "event",
     "component": "EventsPanel",
     "props": {
@@ -9,8 +9,8 @@
     }
   },
   "acolytes": {
-    "state": true,
-    "display": "Acolytes",
+    "display": true,
+    "display_name": "Acolytes",
     "key": "acolytes",
     "component": "AcolytesPanel",
     "props": {
@@ -18,8 +18,8 @@
     }
   },
   "cetus": {
-    "state": true,
-    "display": "Cetus Cycle",
+    "display": true,
+    "display_name": "Cetus Cycle",
     "key": "cetus",
     "component": "TimePanel",
     "props": {
@@ -28,8 +28,8 @@
     }
   },
   "earth": {
-    "state": true,
-    "display": "Earth Cycle",
+    "display": true,
+    "display_name": "Earth Cycle",
     "key": "earth",
     "component": "TimePanel",
     "props": {
@@ -38,8 +38,8 @@
     }
   },
   "vallis": {
-    "state": true,
-    "display": "Vallis Cycle",
+    "display": true,
+    "display_name": "Vallis Cycle",
     "key": "vallis",
     "component": "TimePanel",
     "props": {
@@ -48,8 +48,8 @@
     }
   },
   "bounties": {
-    "state": true,
-    "display": "Bounties Timer",
+    "display": true,
+    "display_name": "Bounties Timer",
     "key": "bounties",
     "component": "BountyPanel",
     "props": {
@@ -58,8 +58,8 @@
     }
   },
   "solaris-bounties": {
-    "state": true,
-    "display": "Solaris Bounties Timer",
+    "display": true,
+    "display_name": "Solaris Bounties Timer",
     "key": "solaris-bounties",
     "component": "BountyPanel",
     "props": {
@@ -68,8 +68,8 @@
     }
   },
   "alerts": {
-    "state": true,
-    "display": "Alerts",
+    "display": true,
+    "display_name": "Alerts",
     "key": "alerts",
     "component": "AlertPanel",
     "props": {
@@ -77,8 +77,8 @@
     }
   },
   "news": {
-    "state": true,
-    "display": "News",
+    "display": true,
+    "display_name": "News",
     "key": "news",
     "component": "NewsPanel",
     "props": {
@@ -86,8 +86,8 @@
     }
   },
   "invasions": {
-    "state": true,
-    "display": "Invasions",
+    "display": true,
+    "display_name": "Invasions",
     "key": "invasions",
     "component": "InvasionsPanel",
     "expand":false,
@@ -96,15 +96,15 @@
     }
   },
   "reset": {
-    "state": true,
-    "display": "Reset Timer",
+    "display": true,
+    "display_name": "Reset Timer",
     "key": "reset",
     "component": "ResetPanel",
     "props": {}
   },
   "sortie": {
-    "state": true,
-    "display": "Sortie",
+    "display": true,
+    "display_name": "Sortie",
     "key": "sortie",
     "component": "SortiePanel",
     "props": {
@@ -112,8 +112,8 @@
     }
   },
   "fissures": {
-    "state": true,
-    "display": "Fissures",
+    "display": true,
+    "display_name": "Fissures",
     "key": "fissures",
     "component": "FissuresPanel",
     "props": {
@@ -121,8 +121,8 @@
     }
   },
   "baro": {
-    "state": true,
-    "display": "Void Trader",
+    "display": true,
+    "display_name": "Void Trader",
     "key": "baro",
     "component": "VoidTraderPanel",
     "props": {
@@ -130,8 +130,8 @@
     }
   },
   "darvo": {
-    "state": true,
-    "display": "Darvo Deals",
+    "display": true,
+    "display_name": "Darvo Deals",
     "key": "darvo",
     "component": "DarvoDealsPanel",
     "props": {
@@ -139,8 +139,8 @@
     }
   },
   "deals": {
-    "state": false,
-    "display": "Sales",
+    "display": false,
+    "display_name": "Sales",
     "key": "deals",
     "component": "SalesPanel",
     "props": {
@@ -148,8 +148,8 @@
     }
   },
   "nightwave": {
-    "state": true,
-    "display": "Nightwave",
+    "display": true,
+    "display_name": "Nightwave",
     "key": "nightwave",
     "component": "NightwavePanel",
     "props": {

--- a/src/components/modalDialogs/NotificationFilters.vue
+++ b/src/components/modalDialogs/NotificationFilters.vue
@@ -35,7 +35,7 @@
             .map((component) => this.$store.getters.trackableState.rewardTypes[component]);
 
           return components
-            .filter((component) => component.state)
+            .filter((component) => component.display)
             .map((component) => component.value);
         },
         set: function(){},
@@ -49,7 +49,7 @@
             .map((component) => this.$store.getters.trackableState.eventTypes[component]);
 
           return components
-            .filter((component) => component.state)
+            .filter((component) => component.display)
             .map((component) => component.value);
         },
         set: function(){},

--- a/src/components/modalDialogs/Settings.vue
+++ b/src/components/modalDialogs/Settings.vue
@@ -17,7 +17,7 @@
         <b-tab title="Components">
           <b-form-group label="Components">
             <b-form-checkbox-group id="components-checks" name="Components" :options="componentStates"
-                v-model="activeComponents" v-on:input="vls => updateComponentState(vals)" switches
+                v-model="activeComponents" v-on:input="vals => updateComponentState(vals)" switches
                 stacked class="settings-group">
             </b-form-checkbox-group>
           </b-form-group>
@@ -87,7 +87,7 @@
       },
       updateComponentState(enabledComponents) {
         Object.keys(this.$store.getters.componentState).forEach((component) => {
-          this.$store.commit('commitComponentState', [component, enabledComponents.includes(component)]);
+          this.$store.commit('commitComponentDisplayMode', [component, enabledComponents.includes(component)]);
         });
       },
       updateTheme(key) {
@@ -104,7 +104,7 @@
             .map((component) => this.$store.getters.componentState[component]);
 
           return components
-            .filter((component) => component.state)
+            .filter((component) => component.display)
             .map((component) => component.key);
         },
         set: function(){},
@@ -114,7 +114,7 @@
 
         return Object.keys(cs).map((component) => {
           return {
-            text: this.$store.getters.componentState[component].display,
+            text: this.$store.getters.componentState[component].display_name,
             value: this.$store.getters.componentState[component].key,
           };
         });

--- a/src/components/modalDialogs/Settings.vue
+++ b/src/components/modalDialogs/Settings.vue
@@ -86,7 +86,6 @@
         this.$store.dispatch('updateWorldstate');
       },
       updateComponentState(enabledComponents) {
-        //store to state
         Object.keys(this.$store.getters.componentState).forEach((component) => {
           this.$store.commit('commitComponentDisplayMode', [component, enabledComponents.includes(component)]);
         });
@@ -115,7 +114,7 @@
 
         return Object.keys(cs).map((component) => {
           return {
-            text: this.$store.getters.componentState[component].display_name,
+            text: this.$store.getters.componentState[component].displayName,
             value: this.$store.getters.componentState[component].key,
           };
         });

--- a/src/components/modalDialogs/Settings.vue
+++ b/src/components/modalDialogs/Settings.vue
@@ -86,6 +86,7 @@
         this.$store.dispatch('updateWorldstate');
       },
       updateComponentState(enabledComponents) {
+        //store to state
         Object.keys(this.$store.getters.componentState).forEach((component) => {
           this.$store.commit('commitComponentDisplayMode', [component, enabledComponents.includes(component)]);
         });

--- a/src/store.js
+++ b/src/store.js
@@ -42,8 +42,8 @@ const mutations = {
   commitPlatform: (state, platform) => {
     state.platform = platform;
   },
-  commitComponentState: (state, [key, newState]) => {
-    state.components[key].state = newState;
+  commitComponentDisplayMode: (state, [key, newState]) => {
+    state.components[key].display = newState;
   },
   commitGridLayout: (state, [components]) => {
     state.grid.components = components;

--- a/src/views/Timer.vue
+++ b/src/views/Timer.vue
@@ -183,7 +183,7 @@ export default {
     layouts: function() {
       return Object.entries(this.components)
         .filter(([key]) => {
-          return this.componentState[key].state;
+          return this.componentState[key].display;
         })
         .reduce((acc, [, sizes]) => {
           Object.entries(sizes).forEach(([size, itemSize]) => {


### PR DESCRIPTION
### Warframe Hub Pull Request
---
**Summary (short):**
Change the name of a local component attribute named 'state' to display.

---
**Description:**
The local states for components had an ambiguously named attribute called 'state'. It is a boolean that tells if the panel should be displayed or not. I changed it to 'display'. However there was already another attribute called 'display' that stored the name of the panel to display on the settings. So I changed that one to 'display_name'.

I noticed however that turning on/off the components takes some time (the page freezes for a second). I don't think it's caused by my changes but it might be worth looking into.

---
**Fixes issue (include link):**
#318 

---
**Mockups, screenshots, evidence:**
None, check the diffs.

---

(Check one)
- [x] Issue fix
- [ ] Suggestion fulfillment
