### PR TITLE
Change component attribute name 'state' to 'display'

### DIFF
--- a/src/assets/json/components.json
+++ b/src/assets/json/components.json
@@ -1,7 +1,7 @@
 {
   "event": {
-    "state": true,
-    "display": "Events",
+    "display": true,
+    "displayName": "Events",
     "key": "event",
     "component": "EventsPanel",
     "props": {
@@ -9,8 +9,8 @@
     }
   },
   "acolytes": {
-    "state": true,
-    "display": "Acolytes",
+    "display": true,
+    "displayName": "Acolytes",
     "key": "acolytes",
     "component": "AcolytesPanel",
     "props": {
@@ -18,8 +18,8 @@
     }
   },
   "cetus": {
-    "state": true,
-    "display": "Cetus Cycle",
+    "display": true,
+    "displayName": "Cetus Cycle",
     "key": "cetus",
     "component": "TimePanel",
     "props": {
@@ -28,8 +28,8 @@
     }
   },
   "earth": {
-    "state": true,
-    "display": "Earth Cycle",
+    "display": true,
+    "displayName": "Earth Cycle",
     "key": "earth",
     "component": "TimePanel",
     "props": {
@@ -38,8 +38,8 @@
     }
   },
   "vallis": {
-    "state": true,
-    "display": "Vallis Cycle",
+    "display": true,
+    "displayName": "Vallis Cycle",
     "key": "vallis",
     "component": "TimePanel",
     "props": {
@@ -48,8 +48,8 @@
     }
   },
   "bounties": {
-    "state": true,
-    "display": "Bounties Timer",
+    "display": true,
+    "displayName": "Bounties Timer",
     "key": "bounties",
     "component": "BountyPanel",
     "props": {
@@ -58,8 +58,8 @@
     }
   },
   "solaris-bounties": {
-    "state": true,
-    "display": "Solaris Bounties Timer",
+    "display": true,
+    "displayName": "Solaris Bounties Timer",
     "key": "solaris-bounties",
     "component": "BountyPanel",
     "props": {
@@ -68,8 +68,8 @@
     }
   },
   "alerts": {
-    "state": true,
-    "display": "Alerts",
+    "display": true,
+    "displayName": "Alerts",
     "key": "alerts",
     "component": "AlertPanel",
     "props": {
@@ -77,8 +77,8 @@
     }
   },
   "news": {
-    "state": true,
-    "display": "News",
+    "display": true,
+    "displayName": "News",
     "key": "news",
     "component": "NewsPanel",
     "props": {
@@ -87,8 +87,8 @@
     "autoCycle": true
   },
   "invasions": {
-    "state": true,
-    "display": "Invasions",
+    "display": true,
+    "displayName": "Invasions",
     "key": "invasions",
     "component": "InvasionsPanel",
     "expand":false,
@@ -97,15 +97,15 @@
     }
   },
   "reset": {
-    "state": true,
-    "display": "Reset Timer",
+    "display": true,
+    "displayName": "Reset Timer",
     "key": "reset",
     "component": "ResetPanel",
     "props": {}
   },
   "sortie": {
-    "state": true,
-    "display": "Sortie",
+    "display": true,
+    "displayName": "Sortie",
     "key": "sortie",
     "component": "SortiePanel",
     "props": {
@@ -113,8 +113,8 @@
     }
   },
   "fissures": {
-    "state": true,
-    "display": "Fissures",
+    "display": true,
+    "displayName": "Fissures",
     "key": "fissures",
     "component": "FissuresPanel",
     "props": {
@@ -122,8 +122,8 @@
     }
   },
   "baro": {
-    "state": true,
-    "display": "Void Trader",
+    "display": true,
+    "displayName": "Void Trader",
     "key": "baro",
     "component": "VoidTraderPanel",
     "props": {
@@ -131,8 +131,8 @@
     }
   },
   "darvo": {
-    "state": true,
-    "display": "Darvo Deals",
+    "display": true,
+    "displayName": "Darvo Deals",
     "key": "darvo",
     "component": "DarvoDealsPanel",
     "props": {
@@ -140,8 +140,8 @@
     }
   },
   "deals": {
-    "state": false,
-    "display": "Sales",
+    "display": false,
+    "displayName": "Sales",
     "key": "deals",
     "component": "SalesPanel",
     "props": {
@@ -149,8 +149,8 @@
     }
   },
   "nightwave": {
-    "state": true,
-    "display": "Nightwave",
+    "display": true,
+    "displayName": "Nightwave",
     "key": "nightwave",
     "component": "NightwavePanel",
     "props": {

--- a/src/components/modalDialogs/NotificationFilters.vue
+++ b/src/components/modalDialogs/NotificationFilters.vue
@@ -35,7 +35,7 @@
             .map((component) => this.$store.getters.trackableState.rewardTypes[component]);
 
           return components
-            .filter((component) => component.state)
+            .filter((component) => component.display)
             .map((component) => component.value);
         },
         set: function(){},
@@ -49,7 +49,7 @@
             .map((component) => this.$store.getters.trackableState.eventTypes[component]);
 
           return components
-            .filter((component) => component.state)
+            .filter((component) => component.display)
             .map((component) => component.value);
         },
         set: function(){},

--- a/src/components/modalDialogs/Settings.vue
+++ b/src/components/modalDialogs/Settings.vue
@@ -17,7 +17,7 @@
         <b-tab title="Components">
           <b-form-group label="Components">
             <b-form-checkbox-group id="components-checks" name="Components" :options="componentStates"
-                v-model="activeComponents" v-on:input="vls => updateComponentState(vals)" switches
+                v-model="activeComponents" v-on:input="vals => updateComponentState(vals)" switches
                 stacked class="settings-group">
             </b-form-checkbox-group>
           </b-form-group>
@@ -87,7 +87,7 @@
       },
       updateComponentState(enabledComponents) {
         Object.keys(this.$store.getters.componentState).forEach((component) => {
-          this.$store.commit('commitComponentState', [component, enabledComponents.includes(component)]);
+          this.$store.commit('commitComponentDisplayMode', [component, enabledComponents.includes(component)]);
         });
       },
       updateTheme(key) {
@@ -104,7 +104,7 @@
             .map((component) => this.$store.getters.componentState[component]);
 
           return components
-            .filter((component) => component.state)
+            .filter((component) => component.display)
             .map((component) => component.key);
         },
         set: function(){},
@@ -114,7 +114,7 @@
 
         return Object.keys(cs).map((component) => {
           return {
-            text: this.$store.getters.componentState[component].display,
+            text: this.$store.getters.componentState[component].displayName,
             value: this.$store.getters.componentState[component].key,
           };
         });

--- a/src/store.js
+++ b/src/store.js
@@ -42,8 +42,8 @@ const mutations = {
   commitPlatform: (state, platform) => {
     state.platform = platform;
   },
-  commitComponentState: (state, [key, newState]) => {
-    state.components[key].state = newState;
+  commitComponentDisplayMode: (state, [key, newState]) => {
+    state.components[key].display = newState;
   },
   commitGridLayout: (state, [components]) => {
     state.grid.components = components;

--- a/src/views/Timer.vue
+++ b/src/views/Timer.vue
@@ -183,7 +183,7 @@ export default {
     layouts: function() {
       return Object.entries(this.components)
         .filter(([key]) => {
-          return this.componentState[key].state;
+          return this.componentState[key].display;
         })
         .reduce((acc, [, sizes]) => {
           Object.entries(sizes).forEach(([size, itemSize]) => {


### PR DESCRIPTION
### Warframe Hub Pull Request
---
**Summary (short):**
Change the name of a local component attribute named 'state' to display.

---
**Description:**
The local states for components had an ambiguously named attribute called 'state'. It is a boolean that tells if the panel should be displayed or not. I changed it to 'display'. However there was already another attribute called 'display' that stored the name of the panel to display on the settings. So I changed that one to 'display_name'.

I noticed however that turning on/off the components takes some time (the page freezes for a second). I don't think it's caused by my changes but it might be worth looking into.

---
**Fixes issue (include link):**
#318 

---
**Mockups, screenshots, evidence:**
None, check the diffs.

---

(Check one)
- [x] Issue fix
- [ ] Suggestion fulfillment
