### PR TITLE
WIP: Trigger grid update on collabsible toggle, Fix #288

### DIFF
--- a/src/views/Timer.vue
+++ b/src/views/Timer.vue
@@ -95,6 +95,9 @@ export default {
   mounted() {
     this.components = this.gridState.components;
     this.lastUpdate = Date.now();
+    this.$root.$on('bv::collapse::sync::state', () => {
+      this.reflow();
+    });
   },
   methods: {
     track() {
@@ -152,17 +155,19 @@ export default {
         return prev;
       }, {});
     },
+    reflow() {
+      if (this.$refs.panelObserver) {
+        this.$refs.panelObserver.forEach((element) => {
+          element.toggleAttribute('updating');
+        });
+        this.$refs.layout.resizeAllItems(2, 'vertical');
+      }
+    },
   },
   watch: {
     worldstate: {
       handler: function() {
-        if (this.$refs.panelObserver) {
-          this.$refs.panelObserver.forEach((element) => {
-            element.toggleAttribute('updating');
-            element.toggleAttribute('updating');
-          });
-          this.$refs.layout.resizeAllItems(2, 'vertical');
-        }
+        this.reflow();
       },
       deep: true,
     },


### PR DESCRIPTION
### Warframe Hub Pull Request
---
**Summary (short):**
This pull request aims to fix collapsibles/spoilers overlapping with other panels when toggled

---
**Description:**
When a b-collapse is toggled, Vue automatically triggers an event called 'bv::collapse::sync::state'. I use this to tell the timer component to update the grid using the same function that is used when the world state is updated.

However, it is a bit messy as this function doesn't also update the height attribute of the panel.

---
**Fixes issue (include link):**
#288 

---

(Check one)
- [x] Issue fix
- [ ] Suggestion fulfillment
