### PR TITLE
Added Fissure sorting

### DIFF
--- a/src/components/panels/FissuresPanel.vue
+++ b/src/components/panels/FissuresPanel.vue
@@ -63,8 +63,8 @@ export default {
       return this.fissures.filter((fissure) => {
         const isFiltered = planets.test(fissure.node);
         return (pState.length > 0 ? !isFiltered : true) && !fissure.expired;
-      })
-      .sort((a, b) => a.tierNum - b.tierNum);
+        })
+        .sort((a, b) => a.tierNum - b.tierNum);
     },
   },
   methods: {

--- a/src/components/panels/FissuresPanel.vue
+++ b/src/components/panels/FissuresPanel.vue
@@ -63,7 +63,7 @@ export default {
       return this.fissures.filter((fissure) => {
         const isFiltered = planets.test(fissure.node);
         return (pState.length > 0 ? !isFiltered : true) && !fissure.expired;
-      });
+      }).sort((a, b) => a.tierNum - b.tierNum);
     },
   },
   methods: {

--- a/src/components/panels/FissuresPanel.vue
+++ b/src/components/panels/FissuresPanel.vue
@@ -63,7 +63,8 @@ export default {
       return this.fissures.filter((fissure) => {
         const isFiltered = planets.test(fissure.node);
         return (pState.length > 0 ? !isFiltered : true) && !fissure.expired;
-      }).sort((a, b) => a.tierNum - b.tierNum);
+      })
+      .sort((a, b) => a.tierNum - b.tierNum);
     },
   },
   methods: {


### PR DESCRIPTION
### Warframe Hub Pull Request
---
**Summary (short):**
Add sorting to fissures to be ordered by tier, like they are in game.

---
**Description:**
Currently order of fissures is semi random, making it hard to scan through the list.
This is a simple change to sort by fissure tier, like the in-game menu is doing it.

---
**Fixes issue (include link):**
Did not open one 😅 

---
**Mockups, screenshots, evidence:**
![image](https://user-images.githubusercontent.com/9322541/63468733-dd4d8a00-c468-11e9-8843-618c50042fcd.png)

---

(Check one)
- [ ] Issue fix
- [x] Suggestion fulfillment
