### PR TITLE
force language to use en as the language header instead of user's browser

### DIFF
--- a/src/store.js
+++ b/src/store.js
@@ -109,7 +109,11 @@ const mutations = {
 const actions = {
   async updateWorldstate(context) {
     const { commit, getters } = context;
-    const res = await fetch(`${apiBase}/${getters.platform}`);
+    const res = await fetch(`${apiBase}/${getters.platform}`, {
+      headers: {
+        'Accept-Language': 'en',
+      },
+    });
     const ws = await res.json();
     commit('commitWs', [getters.platform, ws]);
     if (!notifier) {


### PR DESCRIPTION
**Summary:**
Use forced 'en' language instead of allowing browser to provide language

---
**Fixes issue (include link):**
None

---
**Mockups, screenshots, evidence:**
See deployment

