### PR TITLE
chore(browserlist): upgrade build to use new vue defaults

### DIFF
--- a/.browserlistrc
+++ b/.browserlistrc
@@ -1,5 +1,4 @@
 # Browsers we support
 
-\> 1%
+> 1%
 last 2 versions
-not ie <= 8


### PR DESCRIPTION
**Summary:**
Clean up the browsers we support, given we don't support TLS lower than 1.3

---
**Fixes issue (include link):**
closes #389

---
**Mockups, screenshots, evidence:**
N/A