### PR TITLE
fix: accomodate longer timestamps better

### DIFF
--- a/src/components/panels/NewsPanel.vue
+++ b/src/components/panels/NewsPanel.vue
@@ -85,7 +85,7 @@ body .list-group .list-group-item-borderless .list-group {
 }
 
 .news-time {
-  width: 4em;
+  width: 5em;
   float: left;
 }
 </style>


### PR DESCRIPTION
**Summary:**
accommodate longer short timestamps better for news

---
**Fixes issue (include link):**
N/A

---
**Mockups, screenshots, evidence:**
N/A

