### PR TITLE
UI Improvements

### DIFF
--- a/src/assets/less/common.less
+++ b/src/assets/less/common.less
@@ -136,7 +136,27 @@ div.modal-body {
     height: fit-content;
     padding-left: 1.5rem;
     text-align: left;
+}
 
+@media (max-width: 768px) {
+  .settings-group > div, #sound-checks.settings-group > div {
+    width: 100%;
+    padding-left: 2.5rem;
+  }
+
+  #platform-radios > div {
+    width: 45%;
+    margin-top: 5%;
+  }
+
+  ul.card-header {
+    padding: 0.75rem 0.55rem;
+  }
+
+
+  a.nav-link {
+        padding: 0.4rem .4rem;
+  }
 }
 
 .settings-group > div > input[type="checkbox"]~label,
@@ -254,9 +274,11 @@ div.card-body {
 }
 
 
-#sound-checks.settings-group > div   {
+@media(min-width: 769px) {
+  #sound-checks.settings-group > div   {
     width: 61%;
     padding-left: 2.5rem;
+}
 }
 
 

--- a/src/assets/less/common.less
+++ b/src/assets/less/common.less
@@ -111,8 +111,8 @@ div.modal-body {
 }
 
 #settings-modal .modal-content {
-  height: fit-content;
-  max-height: 88vh;
+  height: 90vh;
+  max-height: 90vh;
 }
 
 .modal .settings-group {
@@ -155,6 +155,11 @@ div.custom-control {
 
 .fissureSettingGroup {
   padding-left: 2%;
+}
+
+.notificationGroup > div.custom-control {
+  width: 46%;
+  max-width: 178px;
 }
 
 .custom-control-label {
@@ -238,6 +243,7 @@ div.card-body {
 
 .themeTabWrapper > .custom-control {
   width: 35%;
+  max-width: 170px;
 }
 
 .sticky-header {

--- a/src/assets/less/common.less
+++ b/src/assets/less/common.less
@@ -150,8 +150,7 @@ div.custom-control {
 
 
 .tab-wrap {
-  max-height: calc((100vh / 3) - 100px);
-  overflow-y: scroll;
+  overflow-y: auto;
 }
 
 .navbar.fixed-bottom {
@@ -238,6 +237,20 @@ div.card-body {
   position: sticky;
   background: inherit;
   z-index: 2;
+}
+
+
+#sound-checks > .custom-control,  {
+    width: 61%;
+    padding-left: 2.5rem;
+}
+
+ #fissureTabBody > .custom-c
+
+div.fit-height {
+  height: 100%;
+  max-height: 100%;
+  overflow: auto;
 }
 
 span.night:before {

--- a/src/assets/less/common.less
+++ b/src/assets/less/common.less
@@ -125,8 +125,8 @@ div.modal-body {
 }
 
 
-div.custom-control {
-  position: relative;
+.settings-group > div {
+    position: relative;
     display: flex;
     flex-wrap: wrap;
     min-height: 1.40625rem;
@@ -135,18 +135,21 @@ div.custom-control {
     width: 23%;
     height: fit-content;
     padding-left: 1.5rem;
+    text-align: left;
+
 }
 
-#components-checks .custom-control {
+.settings-group > div > input[type="checkbox"]~label,
+.settings-group > div > input[type="radio"]~label {
+  cursor: pointer;
+}
+
+#components-checks .settings-group > div  {
     text-align: left;
     width: 30%;
     min-width: 23%;
 }
 
-
-.custom-radio > input, .custom-radio > label {
-  cursor: pointer;
-}
 
 
 .tab-wrap {
@@ -157,14 +160,11 @@ div.custom-control {
   padding-left: 2%;
 }
 
-.notification-group > div.custom-control {
+.notification-group > .settings-group > div {
   width: 46%;
   max-width: 178px;
 }
 
-.custom-control-label {
-  text-align: left;
-}
 
 .navbar.fixed-bottom {
   height: 30px;
@@ -241,7 +241,7 @@ div.card-body {
   margin: 0.75rem 1.25rem;
 }
 
-.themeTabWrapper > .custom-control {
+.themeTabWrapper > .settings-group > div {
   width: 35%;
   max-width: 170px;
 }
@@ -254,12 +254,12 @@ div.card-body {
 }
 
 
-#sound-checks > .custom-control,  {
+#sound-checks.settings-group > div   {
     width: 61%;
     padding-left: 2.5rem;
 }
 
- #fissureTabBody > .custom-c
+
 
 div.fit-height {
   height: 100%;

--- a/src/assets/less/common.less
+++ b/src/assets/less/common.less
@@ -153,6 +153,14 @@ div.custom-control {
   overflow-y: auto;
 }
 
+.fissureSettingGroup {
+  padding-left: 2%;
+}
+
+.custom-control-label {
+  text-align: left;
+}
+
 .navbar.fixed-bottom {
   height: 30px;
 }

--- a/src/assets/less/common.less
+++ b/src/assets/less/common.less
@@ -94,9 +94,10 @@ img {
   margin-top: 20px;
 }
 
-.modal-body {
+div.modal-body {
   height: 100%;
   overflow-y: auto;
+  padding: .1rem 1rem;
 }
 
 .tabs.row {
@@ -106,12 +107,12 @@ img {
 .modal .tab-content {
   height: 100%;
   max-height: calc(100vh - 300px);
-  overflow-y: scroll;
+  overflow-y: auto;
 }
 
 #settings-modal .modal-content {
   height: fit-content;
-  max-height: 90vh;
+  max-height: 88vh;
 }
 
 .modal .settings-group {
@@ -124,7 +125,7 @@ img {
 }
 
 
-.custom-control {
+div.custom-control {
   position: relative;
     display: flex;
     flex-wrap: wrap;

--- a/src/assets/less/common.less
+++ b/src/assets/less/common.less
@@ -95,7 +95,6 @@ img {
 }
 
 .modal-body {
-  max-height: calc(92vh - 300px);
   height: 100%;
   overflow-y: auto;
 }
@@ -111,7 +110,8 @@ img {
 }
 
 #settings-modal .modal-content {
-  height: 671px;
+  height: fit-content;
+  max-height: 90vh;
 }
 
 .modal .settings-group {

--- a/src/assets/less/common.less
+++ b/src/assets/less/common.less
@@ -137,6 +137,13 @@ div.custom-control {
     padding-left: 1.5rem;
 }
 
+#components-checks .custom-control {
+    text-align: left;
+    width: 30%;
+    min-width: 23%;
+}
+
+
 .custom-radio > input, .custom-radio > label {
   cursor: pointer;
 }
@@ -217,9 +224,20 @@ div.custom-control {
   margin-top: -82px;
 }
 
-.card-body {
-  padding: 0;
+div.card-body {
+  padding: 0px;
   margin: 0.75rem 1.25rem;
+}
+
+.themeTabWrapper > .custom-control {
+  width: 35%;
+}
+
+.sticky-header {
+  top:0px;
+  position: sticky;
+  background: inherit;
+  z-index: 2;
 }
 
 span.night:before {

--- a/src/assets/less/common.less
+++ b/src/assets/less/common.less
@@ -97,7 +97,7 @@ img {
 div.modal-body {
   height: 100%;
   overflow-y: auto;
-  padding: .1rem 1rem;
+  padding: 0rem 0rem;
 }
 
 .tabs.row {
@@ -106,7 +106,7 @@ div.modal-body {
 
 .modal .tab-content {
   height: 100%;
-  max-height: calc(100vh - 300px);
+  max-height: 98%;
   overflow-y: auto;
 }
 

--- a/src/assets/less/common.less
+++ b/src/assets/less/common.less
@@ -116,14 +116,12 @@ img {
 
 .modal .settings-group {
   text-align: center;
-  max-width: 250px;
+  display: flex;
+  justify-content: space-around;
   margin-left: auto;
   margin-right: auto;
 }
-.modal .settings-group > div {
-  float: left;
-  clear: both;
-}
+
 
 .tab-wrap {
   max-height: calc((100vh / 3) - 100px);

--- a/src/assets/less/common.less
+++ b/src/assets/less/common.less
@@ -115,11 +115,25 @@ img {
 }
 
 .modal .settings-group {
-  text-align: center;
-  display: flex;
-  justify-content: space-around;
-  margin-left: auto;
-  margin-right: auto;
+    text-align: center;
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: flex-start;
+    margin-left: auto;
+    margin-right: auto;
+}
+
+
+.custom-control {
+  position: relative;
+    display: flex;
+    flex-wrap: wrap;
+    min-height: 1.40625rem;
+    cursor: pointer;
+    margin: 1%;
+    width: 23%;
+    height: fit-content;
+    padding-left: 1.5rem;
 }
 
 .custom-radio > input, .custom-radio > label {

--- a/src/assets/less/common.less
+++ b/src/assets/less/common.less
@@ -122,6 +122,10 @@ img {
   margin-right: auto;
 }
 
+.custom-radio > input, .custom-radio > label {
+  cursor: pointer;
+}
+
 
 .tab-wrap {
   max-height: calc((100vh / 3) - 100px);

--- a/src/assets/less/common.less
+++ b/src/assets/less/common.less
@@ -139,6 +139,12 @@ div.modal-body {
 }
 
 @media (max-width: 768px) {
+
+#settings-modal .modal-content {
+  height: 81vh;
+  max-height: 81vh;
+}
+
   .settings-group > div, #sound-checks.settings-group > div {
     width: 100%;
     padding-left: 2.5rem;

--- a/src/assets/less/common.less
+++ b/src/assets/less/common.less
@@ -153,11 +153,11 @@ div.custom-control {
   overflow-y: auto;
 }
 
-.fissureSettingGroup {
+.fissure-setting-group {
   padding-left: 2%;
 }
 
-.notificationGroup > div.custom-control {
+.notification-group > div.custom-control {
   width: 46%;
   max-width: 178px;
 }

--- a/src/components/modalDialogs/FissureFilters.vue
+++ b/src/components/modalDialogs/FissureFilters.vue
@@ -11,7 +11,7 @@
           v-on:input="(vals) => updateFissureStates(vals)"
           switches
           stacked
-          class="settings-group fissureSettingGroup"
+          class="settings-group fissure-setting-group"
         >
         </b-form-checkbox-group>
       </b-form-group>

--- a/src/components/modalDialogs/FissureFilters.vue
+++ b/src/components/modalDialogs/FissureFilters.vue
@@ -1,7 +1,7 @@
 <template>
   <div id="fissureTabBody">
     Checking the checkbox next to a planet below will disable it from being shown in the fissures list.
-    <div class="tab-wrap fit-height ">
+    <div class="tab-wrap fit-height pt-3">
       <b-form-group label="Fissure Filters">
         <b-form-checkbox-group
           id="fissure-checks"

--- a/src/components/modalDialogs/FissureFilters.vue
+++ b/src/components/modalDialogs/FissureFilters.vue
@@ -1,7 +1,7 @@
 <template>
   <div id="fissureTabBody">
     Checking the checkbox next to a planet below will disable it from being shown in the fissures list.
-    <div class="tab-wrap">
+    <div class="tab-wrap fit-height ">
       <b-form-group label="Fissure Filters">
         <b-form-checkbox-group
           id="fissure-checks"

--- a/src/components/modalDialogs/FissureFilters.vue
+++ b/src/components/modalDialogs/FissureFilters.vue
@@ -11,7 +11,7 @@
           v-on:input="(vals) => updateFissureStates(vals)"
           switches
           stacked
-          class="settings-group"
+          class="settings-group fissureSettingGroup"
         >
         </b-form-checkbox-group>
       </b-form-group>

--- a/src/components/modalDialogs/NotificationFilters.vue
+++ b/src/components/modalDialogs/NotificationFilters.vue
@@ -11,7 +11,7 @@
           v-on:input="(vals) => updateRewardStates(vals)"
           switches
           stacked
-          class="settings-group fissureSettingGroup notificationGroup"
+          class="settings-group fissure-setting-group notification-group"
         >
         </b-form-checkbox-group>
       </b-form-group>
@@ -27,7 +27,7 @@
           v-on:input="(vals) => updateEventStates(vals)"
           switches
           stacked
-          class="settings-group fissureSettingGroup notificationGroup"
+          class="settings-group fissure-setting-group notification-group"
         >
         </b-form-checkbox-group>
       </b-form-group>

--- a/src/components/modalDialogs/NotificationFilters.vue
+++ b/src/components/modalDialogs/NotificationFilters.vue
@@ -11,7 +11,7 @@
           v-on:input="(vals) => updateRewardStates(vals)"
           switches
           stacked
-          class="settings-group"
+          class="settings-group fissureSettingGroup notificationGroup"
         >
         </b-form-checkbox-group>
       </b-form-group>
@@ -27,7 +27,7 @@
           v-on:input="(vals) => updateEventStates(vals)"
           switches
           stacked
-          class="settings-group"
+          class="settings-group fissureSettingGroup notificationGroup"
         >
         </b-form-checkbox-group>
       </b-form-group>

--- a/src/components/modalDialogs/NotificationFilters.vue
+++ b/src/components/modalDialogs/NotificationFilters.vue
@@ -1,6 +1,6 @@
 <template>
   <div id="notificationsTabBody">
-    Check the checkbock for entries you want notifications for:
+    Check the checkbox for entries you want notifications for:
     <div class="tab-wrap">
       <b-form-group label="Reward Filters">
         <b-form-checkbox-group

--- a/src/components/modalDialogs/NotificationFilters.vue
+++ b/src/components/modalDialogs/NotificationFilters.vue
@@ -1,7 +1,7 @@
 <template>
   <div id="notificationsTabBody">
     Check the checkbox for entries you want notifications for:
-    <div class="tab-wrap">
+    <div class="tab-wrap pt-3">
       <b-form-group label="Reward Filters">
         <b-form-checkbox-group
           id="reward-checks"

--- a/src/components/modalDialogs/Settings.vue
+++ b/src/components/modalDialogs/Settings.vue
@@ -1,5 +1,5 @@
 <template>
-  <b-modal @shown="checkNotifications" id="settings-modal" class="settings-modal" centered size="md" title="Settings">
+  <b-modal @shown="checkNotifications" id="settings-modal" class="settings-modal" centered size="xl" title="Settings">
     <b-tabs card vertical>
       <b-tab title="Platform">
         <Platforms />

--- a/src/components/modalDialogs/Settings.vue
+++ b/src/components/modalDialogs/Settings.vue
@@ -30,7 +30,7 @@
             v-model="theme"
             name="theme radios"
             v-on:change="updateTheme"
-            class="settings-group"
+            class="settings-group themeTabWrapper"
           >
             <b-form-radio v-for="theme in getThemes" :key="theme.key" :value="theme.key">
               <i :class="theme.faclass" :style="themeIconStyle"></i>

--- a/src/components/modalDialogs/SoundFilters.vue
+++ b/src/components/modalDialogs/SoundFilters.vue
@@ -2,7 +2,7 @@
   <div id="soundsTabBody">
     Checking the checkbox next to an option will allow a sound to be played for those new items.
 
-    <div class="tab-wrap">
+    <div class="tab-wrap fit-height">
       <b-form-group label="Sound Filters">
         <b-form-checkbox-group
           id="sound-checks"

--- a/src/components/modalDialogs/SoundFilters.vue
+++ b/src/components/modalDialogs/SoundFilters.vue
@@ -2,7 +2,7 @@
   <div id="soundsTabBody">
     Checking the checkbox next to an option will allow a sound to be played for those new items.
 
-    <div class="tab-wrap fit-height">
+    <div class="tab-wrap fit-height pt-3">
       <b-form-group label="Sound Filters">
         <b-form-checkbox-group
           id="sound-checks"


### PR DESCRIPTION
**Summary:**
Changes:
1. Improved the UI of Settings modal.

The Current Setting modal is not user-friendly.  A lot of empty spaces and unnecessary scroll bars are present. This make it difficult to navigate and gives a bad user experience.
---
**Fixes issue (include link):**


---
**Mockups, screenshots, evidence:**
Current Platform Tab:
![Earlier_PlatformTab](https://user-images.githubusercontent.com/8160121/75097037-13142c80-55cc-11ea-97d6-51bdf071e1bc.png)
Newer Platform Tab:
![Newer_PlatformTab](https://user-images.githubusercontent.com/8160121/75097039-17d8e080-55cc-11ea-8040-bcc650339398.png)
urrent Component Tab:
![Earlier_ComponentTab](https://user-images.githubusercontent.com/8160121/75097052-36d77280-55cc-11ea-90a9-2e66c44223cf.png)
Newer Component Tab:
![Newer_ComponentTab](https://user-images.githubusercontent.com/8160121/75097054-3b039000-55cc-11ea-8b35-4a4504ff0bcd.png)
Current Fissure Tab:
![Earlier_FissureTab](https://user-images.githubusercontent.com/8160121/75097055-3f2fad80-55cc-11ea-9739-7f8e03456968.png)
New Fissure Tab:
![Newer_FissureTab](https://user-images.githubusercontent.com/8160121/75097057-40f97100-55cc-11ea-904c-c24516035811.png)
Current Language Tab:
![Earlier_LanguageTab](https://user-images.githubusercontent.com/8160121/75097060-435bcb00-55cc-11ea-8a18-6bbcdc654ce7.png)
Newer Language Tab:
![Newer_LanguageTab](https://user-images.githubusercontent.com/8160121/75097061-45258e80-55cc-11ea-9777-79367bf30c64.png)
Current Notification Tab:
![Earlier_NotificationTab](https://user-images.githubusercontent.com/8160121/75097062-4656bb80-55cc-11ea-8747-070a7b8de1ba.png)
Newer Notification Tab:
![Newer_NotificationTab](https://user-images.githubusercontent.com/8160121/75097065-4951ac00-55cc-11ea-8f6c-01cbb911b7c9.png)
Current Sound Tab:
![Earlier_SoundTab](https://user-images.githubusercontent.com/8160121/75097066-4bb40600-55cc-11ea-9539-4ebc200e2272.png)
Newer Sound Tab:
![Newer_SoundFiltersTab](https://user-images.githubusercontent.com/8160121/75097067-4ce53300-55cc-11ea-993f-bba9a14ad5f1.png)
Current Theme Tab:
![Earlier_ThemeTab](https://user-images.githubusercontent.com/8160121/75097068-4f478d00-55cc-11ea-91c0-0712a29a57b8.png)
Newer Theme Tab:
![Newer_ThemeTab](https://user-images.githubusercontent.com/8160121/75097069-51115080-55cc-11ea-8cb0-d63260e55a36.png)





