### PR TITLE
Slim up invasions, outpost

### DIFF
--- a/src/components/AsyncItemThumb.vue
+++ b/src/components/AsyncItemThumb.vue
@@ -1,0 +1,55 @@
+<template>
+  <span>
+    <div v-if="!img">{{ this.alt }}</div>
+    <div v-else>
+      <img :src="img" :alt="this.alt" :id="this.id" class="async-thumb" height="20px" />
+      <b-tooltip :target="this.id" triggers="hover" placement="bottom">
+        {{ this.alt }}
+      </b-tooltip>
+    </div>
+  </span>
+</template>
+
+<style scoped>
+.async-thumb {
+  pointer-events: inherit;
+}
+</style>
+
+<script>
+import fetch from 'node-fetch';
+import utilities from '@/utilities.js';
+
+export default {
+  name: 'item-thumb',
+  props: ['alt'],
+  data() {
+    return {
+      id: utilities.makeid(),
+      img: null,
+    };
+  },
+  methods: {
+    fetch: async function() {
+      const stripped = this.alt
+        .replace(/\d+\s+/i, '')
+        .replace('Blueprint', '')
+        .replace('Receiver', '')
+        .replace('Hilt', '')
+        .replace('Blade', '')
+        .replace('Stock', '')
+        .trim();
+      const url = `https://api.warframestat.us/items/search/${stripped.toLowerCase()}`;
+      const data = (await fetch(url).then((d) => d.json())).filter((d) => d.name === stripped);
+      if (!data || !data[0].imageName) {
+        return;
+      } else {
+        this.img = `https://cdn.warframestat.us/img/${data[0].imageName}`;
+      }
+    },
+  },
+  created: function() {
+    this.fetch();
+  },
+};
+</script>

--- a/src/components/AsyncItemThumb.vue
+++ b/src/components/AsyncItemThumb.vue
@@ -2,7 +2,7 @@
   <span>
     <div v-if="!img">{{ this.alt }}</div>
     <div v-else>
-      <img :src="img" :alt="this.alt" :id="this.id" class="async-thumb" height="20px" />
+      <img :src="img" :alt="this.alt" :id="this.id" class="async-thumb" :width="`${this.width}px`" />
       <b-tooltip :target="this.id" triggers="hover" placement="bottom">
         {{ this.alt }}
       </b-tooltip>
@@ -22,7 +22,16 @@ import utilities from '@/utilities.js';
 
 export default {
   name: 'item-thumb',
-  props: ['alt'],
+  props: {
+    alt: {
+      type: String,
+      default: '',
+    },
+    width: {
+      type: Number,
+      default: 20,
+    },
+  },
   data() {
     return {
       id: utilities.makeid(),
@@ -44,7 +53,8 @@ export default {
       if (!data || !data[0].imageName) {
         return;
       } else {
-        this.img = `https://cdn.warframestat.us/img/${data[0].imageName}`;
+        this.img = `https://cdn.warframestat.us/o_webp,progressive_true,rs_${this.width *
+          3}/https://cdn.warframestat.us/img/${data[0].imageName}`;
       }
     },
   },

--- a/src/components/AsyncItemThumb.vue
+++ b/src/components/AsyncItemThumb.vue
@@ -4,7 +4,8 @@
     <div v-else>
       <img :src="img" :alt="this.alt" :id="this.id" class="async-thumb" :width="`${this.width}px`" />
       <b-tooltip :target="this.id" triggers="hover" placement="bottom">
-        {{ this.alt }}
+        <img :src="img" :alt="this.alt" :id="this.id" class="async-thumb" :width="`${this.width * 5}px`" />
+        <div>{{ this.alt }}</div>
       </b-tooltip>
     </div>
   </span>
@@ -54,7 +55,7 @@ export default {
         return;
       } else {
         this.img = `https://cdn.warframestat.us/o_webp,progressive_true,rs_${this.width *
-          3}/https://cdn.warframestat.us/img/${data[0].imageName}`;
+          8}/https://cdn.warframestat.us/img/${data[0].imageName}`;
       }
     },
   },

--- a/src/components/Invasion.vue
+++ b/src/components/Invasion.vue
@@ -4,7 +4,7 @@
       <span
         ><b>{{ invasion.node }}</b> - {{ invasion.desc }}</span
       >
-      <i :id="`${invasion.id}_tooltip`" class="fas fa-xs fa-info-circle ml-2" />
+      <i :id="`${invasion.id}_tooltip`" class="fas fa-sm fa-info-circle ml-2" />
       <b-tooltip :target="`${invasion.id}_tooltip`" placement="right" class="text-center">
         <TimeBadge :starttime="invasion.activation" :counter="true" :interval="1000" />
         <div class="eta">

--- a/src/components/Invasion.vue
+++ b/src/components/Invasion.vue
@@ -4,15 +4,15 @@
       <span
         ><b>{{ invasion.node }}</b> - {{ invasion.desc }}</span
       >
-      <b-btn :id="`${invasion.id}_tooltip`" class="pull-right py-0" size="sm" variant="secondary">?</b-btn>
-      <b-tooltip :target="`${invasion.id}_tooltip`" placement="top" class="text-center">
-        &nbsp;
+      <i :id="`${invasion.id}_tooltip`" class="fas fa-xs fa-info-circle ml-2" />
+      <b-tooltip :target="`${invasion.id}_tooltip`" placement="right" class="text-center">
         <TimeBadge :starttime="invasion.activation" :counter="true" :interval="1000" />
-        <br />
-        {{ eta(invasion) }}
+        <div class="eta">
+          {{ eta(invasion) }}
+        </div>
       </b-tooltip>
     </div>
-    <b-row class="invasion-rewards">
+    <b-row class="invasion-rewards p-0">
       <b-col>
         <div class="pull-left">
           <b-badge
@@ -20,29 +20,33 @@
             v-for="item in invasion.attackerReward.items"
             :key="item"
             :variant="getLabelColor(invasion.attackingFaction)"
-            >{{ item }}</b-badge
-          >
+            class="ml-n3"
+            ><item-thumb :alt="item"
+          /></b-badge>
           <b-badge
             tag="div"
             v-for="item in invasion.attackerReward.countedItems"
             :key="item.type"
             :variant="getLabelColor(invasion.attackingFaction)"
-            >{{ countedItem(item) }}</b-badge
-          >
+            class="ml-n3"
+            ><item-thumb :alt="countedItem(item)"
+          /></b-badge>
         </div>
         <div class="pull-right">
           <b-badge
             v-for="item in invasion.defenderReward.items"
             :key="item"
             :variant="getLabelColor(invasion.defendingFaction)"
-            >{{ item }}</b-badge
-          >
+            class="mr-n3"
+            ><item-thumb :alt="item"
+          /></b-badge>
           <b-badge
             v-for="item in invasion.defenderReward.countedItems"
             :key="item.type"
             :variant="getLabelColor(invasion.defendingFaction)"
-            >{{ countedItem(item) }}</b-badge
-          >
+            class="mr-n3"
+            ><item-thumb :alt="countedItem(item)"
+          /></b-badge>
         </div>
       </b-col>
     </b-row>
@@ -51,18 +55,63 @@
         <b-progress-bar
           :variant="getLabelColor(invasion.attackingFaction)"
           :value="invasion.completion"
+          :id="`${this.id}-attacker-progress`"
         ></b-progress-bar>
         <b-progress-bar
           :variant="getLabelColor(invasion.defendingFaction)"
           :value="100 - invasion.completion"
+          :id="`${this.id}-defender-progress`"
         ></b-progress-bar>
+        <b-tooltip :target="`${this.id}-attacker-progress`" placement="bottom" class="text-center">
+          <HubImg :src="atkFactionImg" class="hubimg" name="Attacking Faction" width="20px" height="20px" />
+          <div class="pl-2">{{ invasion.attackingFaction }}</div>
+        </b-tooltip>
+        <b-tooltip :target="`${this.id}-defender-progress`" placement="bottom" class="text-center">
+          <HubImg :src="defFactionImg" class="hubimg" name="Defending Faction" width="20px" height="20px" />
+          <div class="pl-2">{{ invasion.defendingFaction }}</div>
+        </b-tooltip>
       </b-progress>
     </b-row>
   </div>
 </template>
 
+<style scoped>
+.invasion-rewards {
+  margin-top: -25px;
+}
+
+.invasion-rewards {
+  pointer-events: none;
+}
+
+.invasion-rewards .badge > * {
+  pointer-events: auto;
+}
+
+.hubimg {
+  filter: invert(100%);
+}
+
+.hubimg + div {
+  display: inline-block;
+}
+
+.eta {
+  font-size: 75%;
+}
+</style>
+
 <script>
 import TimeBadge from '@/components/TimeBadge.vue';
+import HubImg from '@/components/HubImg.vue';
+import AsyncItemThumb from '@/components/AsyncItemThumb';
+import utilities from '@/utilities.js';
+
+import corpus from '@/assets/img/factions/corpus.svg';
+import corrupted from '@/assets/img/factions/corrupted.svg';
+import grineer from '@/assets/img/factions/grineer.svg';
+import infested from '@/assets/img/factions/infested.svg';
+import sentient from '@/assets/img/factions/sentient.svg';
 
 export default {
   name: 'Invasion',
@@ -72,14 +121,33 @@ export default {
       styleObject: {
         display: 'inline',
       },
+      id: utilities.makeid(),
+      fImg: {
+        corpus: corpus,
+        grineer: grineer,
+        infested: infested,
+        infestation: infested,
+        corrupted: corrupted,
+        orokin: corrupted,
+        sentient: sentient,
+      },
     };
+  },
+  computed: {
+    atkFactionImg() {
+      return this.fImg[this.$props.invasion.attackingFaction.toLowerCase()] || corrupted;
+    },
+    defFactionImg() {
+      return this.fImg[this.$props.invasion.defendingFaction.toLowerCase()] || corrupted;
+    },
   },
   methods: {
     eta: function(invasion) {
       const eta = invasion.eta
         .replace('-Infinityd', '??')
         .replace('Infinityd', '??')
-        .replace(/\s\d\d?s/gi, '');
+        .replace(/\s\d\d?s/gi, '')
+        .trim();
       return `(${this.$t('invasions.eta')} ${eta})*`;
     },
     getLabelColor: function(faction) {
@@ -89,6 +157,7 @@ export default {
         case 'Grineer':
           return 'danger';
         case 'Infested':
+        case 'Infestation':
           return 'success';
         case 'Corrupted':
           return 'warning';
@@ -114,6 +183,8 @@ export default {
   },
   components: {
     TimeBadge,
+    HubImg,
+    'item-thumb': AsyncItemThumb,
   },
 };
 </script>

--- a/src/components/panels/SentientOutpostsPanel.vue
+++ b/src/components/panels/SentientOutpostsPanel.vue
@@ -2,24 +2,24 @@
   <HubPanelWrap :title="headertext" class="sentientoutpost">
     <b-list-group>
       <b-list-group-item class="list-group-item-borderbottom" v-if="sentientOutposts.active">
-        <b>{{ sentientOutposts.mission.node }}</b> - {{ sentientOutposts.mission.faction }} -
-        {{ sentientOutposts.mission.type }}
-        <b-btn id="beta_tooltip" class="pull-right py-0" size="sm" variant="primary">!</b-btn>
-        <b-tooltip target="beta_tooltip" placement="top" class="text-center">
-          {{ $t('sentientoutpost.tooltip1') }}
-          <br />
-          {{ $t('sentientoutpost.tooltip2') }}
-        </b-tooltip>
+        <span class="pull-left">
+          <HubImg :src="sentient" :name="this.$t('factions.sentient')" :style="factionImg" width="20px" height="20px" />
+          <b>{{ sentientOutposts.mission.node }}</b> - {{ sentientOutposts.mission.faction }} -
+          {{ sentientOutposts.mission.type }}
+          <i id="para_tooltip" class="fa-xs fas fa-exclamation-triangle"></i>
+          <b-tooltip target="para_tooltip" placement="top" class="text-center">
+            {{ $t('sentientoutpost.warn') }}
+          </b-tooltip>
+        </span>
+        <TimeBadge :starttime="curr.activation" :endtime="curr.expiry" :interval="1000" />
       </b-list-group-item>
-      <b-list-group-item class="list-group-item-borderlessbottom p-0" v-if="!sentientOutposts.active">
-        <b-btn id="beta_tooltip" class="pull-right py-0" size="sm" variant="primary">!</b-btn>
-        <b-tooltip target="beta_tooltip" placement="top" class="text-center">
-          {{ $t('sentientoutpost.tooltip1') }}
-          <br />
-          {{ $t('sentientoutpost.tooltip2') }}
-        </b-tooltip>
+      <b-list-group-item class="list-group-item-borderbottom p-2" v-if="!sentientOutposts.active">
+        <span class="pull-left">
+          <i class="far fa-eye-slash faIcon" v-b-tooltip :title="this.$t('sentientoutpost.none')"></i>
+          <b>Prediction</b></span
+        >
+        <TimeBadge :starttime="predNext.activation" :endtime="predNext.expiry" :interval="1000" />
       </b-list-group-item>
-      <NoDataItem v-if="!sentientOutposts.active" :text="$t('sentientoutpost.outpostsL')" />
     </b-list-group>
   </HubPanelWrap>
 </template>
@@ -28,6 +28,9 @@
 import TimeBadge from '@/components/TimeBadge.vue';
 import HubPanelWrap from '@/components/HubPanelWrap';
 import NoDataItem from '@/components/NoDataItem.vue';
+import HubImg from '@/components/HubImg.vue';
+
+import sentient from '@/assets/img/factions/sentient.svg';
 
 export default {
   name: 'SentientOutpostsPanel',
@@ -36,11 +39,58 @@ export default {
     headertext() {
       return this.$t('sentientoutpost.header');
     },
+    curr() {
+      const defStart = new Date(this.$props.sentientOutposts.activation).getTime();
+      const defEnd = new Date(this.$props.sentientOutposts.expiry).getTime();
+      const predStart = new Date(this.$props.sentientOutposts.previous.activation).getTime();
+      const predEnd = new Date(this.$props.sentientOutposts.previous.expiry).getTime();
+      if (defStart < predStart) {
+        return {
+          activation: new Date(defStart),
+          expiry: new Date(defEnd),
+        };
+      } else {
+        return {
+          activation: new Date(predStart),
+          expiry: new Date(predEnd),
+        };
+      }
+    },
+    predNext() {
+      const defStart = new Date(this.$props.sentientOutposts.activation).getTime();
+      const defEnd = new Date(this.$props.sentientOutposts.expiry).getTime();
+      const predStart = new Date(this.$props.sentientOutposts.previous.activation).getTime();
+      const predEnd = new Date(this.$props.sentientOutposts.previous.expiry).getTime();
+      if (defStart > predStart) {
+        return {
+          activation: new Date(defStart),
+          expiry: new Date(defEnd),
+        };
+      } else {
+        return {
+          activation: new Date(predStart),
+          expiry: new Date(predEnd),
+        };
+      }
+    },
+  },
+  data() {
+    return {
+      sentient: sentient,
+      factionImg: {
+        filter: 'invert(100%)',
+        'margin-top': '-3px',
+        'margin-right': '5px',
+        width: '25px',
+        height: '25px',
+      },
+    };
   },
   components: {
     HubPanelWrap,
     TimeBadge,
     NoDataItem,
+    HubImg,
   },
   methods: {
     now() {

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -67,6 +67,9 @@
     "standStages": "Standing Stages",
     "rewards": "Rewards"
   },
+  "factions": {
+    "sentient": "Sentient"
+  },
   "fissures": {
     "header": "Fissures"
   },
@@ -109,8 +112,10 @@
   "sentientoutpost": {
     "tooltip1": "This component is in active development because of the recent update.",
     "tooltip2": "Estimated cycle is 30 minutes of active time and 3 hours of inactive time.",
-    "header": "Sentient Outposts (Beta)",
-    "outpostsL": "Outposts"
+    "header": "Anomalies (Beta)",
+    "outpostsL": "Outposts",
+    "none": "No Current Anomalies",
+    "warn": "Don't forget your Paracesis!"
   },
   "sortie": {
     "header": "Sortie"
@@ -124,7 +129,7 @@
     "startL": "Starts in:",
     "endL": "Ends in:",
     "ongoingL": "Ongoing for:",
-    "expiredL": "Expired:",
+    "expiredL": "Expired",
     "depart": "Departs",
     "arrive": "Arrives at"
   },


### PR DESCRIPTION
**Summary:**
Slim up the invasions panel with more hovers & less padding
fixes #388 : adds a timer to sentient outpost, no more beta tooltip or no-data section

---
**Mockups, screenshots, evidence:**

Anomalies:
![image](https://user-images.githubusercontent.com/7128721/76119123-5d29e480-5fb4-11ea-9041-159ed3ead089.png)

Invasions:
![image](https://user-images.githubusercontent.com/7128721/76119140-69ae3d00-5fb4-11ea-986e-4884cfb07722.png)
![image](https://user-images.githubusercontent.com/7128721/76119159-729f0e80-5fb4-11ea-8fe4-6873c7c8b88b.png)

