### PR TITLE
feat: cleanups & arbitration notifications

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,7 +22,4 @@ jobs:
     - name: Install Dependencies
       run: npm install
     - name: Run linters
-      uses: wearerequired/lint-action@v1
-      with:
-        github_token: ${{ secrets.github_token }}
-        eslint: true
+      run: npm run lint

--- a/package-lock.json
+++ b/package-lock.json
@@ -2356,77 +2356,95 @@
       }
     },
     "@sentry/browser": {
-      "version": "5.27.3",
-      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-5.27.3.tgz",
-      "integrity": "sha512-vczS+XTW4Nk2A7TIpAw8IVFHpp+NK6mV9euBG2I61Bs2QbQY9yKLfbjiln/yH2Q8X4THX6MKa0GuiPoCEeq3uw==",
+      "version": "5.30.0",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-5.30.0.tgz",
+      "integrity": "sha512-rOb58ZNVJWh1VuMuBG1mL9r54nZqKeaIlwSlvzJfc89vyfd7n6tQ1UXMN383QBz/MS5H5z44Hy5eE+7pCrYAfw==",
       "dev": true,
       "requires": {
-        "@sentry/core": "5.27.3",
-        "@sentry/types": "5.27.3",
-        "@sentry/utils": "5.27.3",
+        "@sentry/core": "5.30.0",
+        "@sentry/types": "5.30.0",
+        "@sentry/utils": "5.30.0",
         "tslib": "^1.9.3"
       }
     },
     "@sentry/core": {
-      "version": "5.27.3",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-5.27.3.tgz",
-      "integrity": "sha512-yqepQO88jSt5hy0awpk61AxI4oHB09LjVbUEk4nJDg+1YXuND23cuZvH+Sp2jCZX2vrsw2tefwflToYfA8/U2w==",
+      "version": "5.30.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-5.30.0.tgz",
+      "integrity": "sha512-TmfrII8w1PQZSZgPpUESqjB+jC6MvZJZdLtE/0hZ+SrnKhW3x5WlYLvTXZpcWePYBku7rl2wn1RZu6uT0qCTeg==",
       "dev": true,
       "requires": {
-        "@sentry/hub": "5.27.3",
-        "@sentry/minimal": "5.27.3",
-        "@sentry/types": "5.27.3",
-        "@sentry/utils": "5.27.3",
+        "@sentry/hub": "5.30.0",
+        "@sentry/minimal": "5.30.0",
+        "@sentry/types": "5.30.0",
+        "@sentry/utils": "5.30.0",
         "tslib": "^1.9.3"
       }
     },
     "@sentry/hub": {
-      "version": "5.27.3",
-      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-5.27.3.tgz",
-      "integrity": "sha512-icEH3hr6NVQkpowXZcPOs9IgJZP5lMKtvud4mVioSpkd+NxtRdKrGEX4eF2TCviOJc9Md0mV4K+aL5Au7hxggQ==",
+      "version": "5.30.0",
+      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-5.30.0.tgz",
+      "integrity": "sha512-2tYrGnzb1gKz2EkMDQcfLrDTvmGcQPuWxLnJKXJvYTQDGLlEvi2tWz1VIHjunmOvJrB5aIQLhm+dcMRwFZDCqQ==",
       "dev": true,
       "requires": {
-        "@sentry/types": "5.27.3",
-        "@sentry/utils": "5.27.3",
+        "@sentry/types": "5.30.0",
+        "@sentry/utils": "5.30.0",
         "tslib": "^1.9.3"
       }
     },
     "@sentry/integrations": {
-      "version": "5.27.3",
-      "resolved": "https://registry.npmjs.org/@sentry/integrations/-/integrations-5.27.3.tgz",
-      "integrity": "sha512-lmkYH3g1ZW9I8g3SXQNYIfNc9gaNoqJUxgTI9d0AQph+mSB8Y3lx50NYMAfK74XgiC3VJ9j8kWstdQCMbgfXpQ==",
+      "version": "5.30.0",
+      "resolved": "https://registry.npmjs.org/@sentry/integrations/-/integrations-5.30.0.tgz",
+      "integrity": "sha512-Fqh4ALLoQWdd+1ih0iBduANWFyNmFWMxwvBu3V/wLDRi8OcquI0lEzWai1InzTJTiNhRHPnhuU++l/vkO0OCww==",
       "dev": true,
       "requires": {
-        "@sentry/types": "5.27.3",
-        "@sentry/utils": "5.27.3",
+        "@sentry/types": "5.30.0",
+        "@sentry/utils": "5.30.0",
         "localforage": "1.8.1",
         "tslib": "^1.9.3"
+      },
+      "dependencies": {
+        "@sentry/types": {
+          "version": "5.30.0",
+          "resolved": "https://registry.npmjs.org/@sentry/types/-/types-5.30.0.tgz",
+          "integrity": "sha512-R8xOqlSTZ+htqrfteCWU5Nk0CDN5ApUTvrlvBuiH1DyP6czDZ4ktbZB0hAgBlVcK0U+qpD3ag3Tqqpa5Q67rPw==",
+          "dev": true
+        },
+        "@sentry/utils": {
+          "version": "5.30.0",
+          "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-5.30.0.tgz",
+          "integrity": "sha512-zaYmoH0NWWtvnJjC9/CBseXMtKHm/tm40sz3YfJRxeQjyzRqNQPgivpd9R/oDJCYj999mzdW382p/qi2ypjLww==",
+          "dev": true,
+          "requires": {
+            "@sentry/types": "5.30.0",
+            "tslib": "^1.9.3"
+          }
+        }
       }
     },
     "@sentry/minimal": {
-      "version": "5.27.3",
-      "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-5.27.3.tgz",
-      "integrity": "sha512-ng01cM0rsE1RMjqVTpPLN0ZVkTo0I675usM1krkpQe8ddW6tfQ6EJWpt02/BrpQZRQzTtfWp6/RyB1KFXg6icg==",
+      "version": "5.30.0",
+      "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-5.30.0.tgz",
+      "integrity": "sha512-BwWb/owZKtkDX+Sc4zCSTNcvZUq7YcH3uAVlmh/gtR9rmUvbzAA3ewLuB3myi4wWRAMEtny6+J/FN/x+2wn9Xw==",
       "dev": true,
       "requires": {
-        "@sentry/hub": "5.27.3",
-        "@sentry/types": "5.27.3",
+        "@sentry/hub": "5.30.0",
+        "@sentry/types": "5.30.0",
         "tslib": "^1.9.3"
       }
     },
     "@sentry/types": {
-      "version": "5.27.3",
-      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-5.27.3.tgz",
-      "integrity": "sha512-PkWhMArFMxBb1g3HtMEL8Ea9PYae2MU0z9CMIWiqzerFy2ZpKG98IU3pt8ic4JkmKQdwB8hDiZpRPMHhW0WYwQ==",
+      "version": "5.30.0",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-5.30.0.tgz",
+      "integrity": "sha512-R8xOqlSTZ+htqrfteCWU5Nk0CDN5ApUTvrlvBuiH1DyP6czDZ4ktbZB0hAgBlVcK0U+qpD3ag3Tqqpa5Q67rPw==",
       "dev": true
     },
     "@sentry/utils": {
-      "version": "5.27.3",
-      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-5.27.3.tgz",
-      "integrity": "sha512-R9WvFrRBALZvCzu/9BsuXBCfkNxz4MwdBNSXaBsJo4afQw1ljkjIc9DpHzlL9S9goIwXo81Buwmr5gGDO6aH+Q==",
+      "version": "5.30.0",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-5.30.0.tgz",
+      "integrity": "sha512-zaYmoH0NWWtvnJjC9/CBseXMtKHm/tm40sz3YfJRxeQjyzRqNQPgivpd9R/oDJCYj999mzdW382p/qi2ypjLww==",
       "dev": true,
       "requires": {
-        "@sentry/types": "5.27.3",
+        "@sentry/types": "5.30.0",
         "tslib": "^1.9.3"
       }
     },
@@ -2547,9 +2565,9 @@
       "dev": true
     },
     "@types/node-fetch": {
-      "version": "2.5.7",
-      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.5.7.tgz",
-      "integrity": "sha512-o2WVNf5UhWRkxlf6eq+jMZDu7kjgpgJfl4xVNlvryc95O/6F2ld8ztKX+qu+Rjyet93WAWm5LjeX9H5FGkODvw==",
+      "version": "2.5.8",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.5.8.tgz",
+      "integrity": "sha512-fbjI6ja0N5ZA8TV53RUqzsKNkl9fv8Oj3T7zxW7FGv1GSH7gwJaNF8dzCjrqKaxKeUpTz4yT1DaJFq/omNpGfw==",
       "dev": true,
       "requires": {
         "@types/node": "*",
@@ -2557,9 +2575,9 @@
       },
       "dependencies": {
         "form-data": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.0.tgz",
-          "integrity": "sha512-CKMFDglpbMi6PyN+brwB9Q/GOw0eAnsrEZDgcsH5Krhz5Od/haKHAX0NmQfha2zPPz0JpWzA7GJHGSnvCRLWsg==",
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
+          "integrity": "sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==",
           "dev": true,
           "requires": {
             "asynckit": "^0.4.0",
@@ -2865,20 +2883,20 @@
       }
     },
     "@vue/cli-plugin-pwa": {
-      "version": "4.5.6",
-      "resolved": "https://registry.npmjs.org/@vue/cli-plugin-pwa/-/cli-plugin-pwa-4.5.6.tgz",
-      "integrity": "sha512-jMTBo9oR3mkwcqFbtgbKgfuYLZoivDoH5KEwqOkzqamuapOUazAbmlrad0XSF92MKcF8XxWrdZjsEsD/TshDPw==",
+      "version": "4.5.11",
+      "resolved": "https://registry.npmjs.org/@vue/cli-plugin-pwa/-/cli-plugin-pwa-4.5.11.tgz",
+      "integrity": "sha512-7wvNdR8EXRWaLlybPlk4B6+lE8y+sG2kXq69EyH4ILRmZnFYc22dY22eUhR1EIFTmRxHR0g8qDBrp1BvaNeaYA==",
       "dev": true,
       "requires": {
-        "@vue/cli-shared-utils": "^4.5.6",
+        "@vue/cli-shared-utils": "^4.5.11",
         "webpack": "^4.0.0",
         "workbox-webpack-plugin": "^4.3.1"
       },
       "dependencies": {
         "@vue/cli-shared-utils": {
-          "version": "4.5.6",
-          "resolved": "https://registry.npmjs.org/@vue/cli-shared-utils/-/cli-shared-utils-4.5.6.tgz",
-          "integrity": "sha512-p6ePDlEa7Xc0GEt99KDOCwPZtR7UnoEaZLMfwPYU5LAWkdCmtAw8HPAY/WWcjtoiaAkY4k9tz7ZehQasZ9mJxg==",
+          "version": "4.5.11",
+          "resolved": "https://registry.npmjs.org/@vue/cli-shared-utils/-/cli-shared-utils-4.5.11.tgz",
+          "integrity": "sha512-+aaQ+ThQG3+WMexfSWNl0y6f43edqVqRNbguE53F3TIH81I7saS5S750ayqXhZs2r6STJJyqorQnKtAWfHo29A==",
           "dev": true,
           "requires": {
             "@hapi/joi": "^15.0.1",
@@ -2963,18 +2981,18 @@
       }
     },
     "@vue/cli-plugin-router": {
-      "version": "4.5.6",
-      "resolved": "https://registry.npmjs.org/@vue/cli-plugin-router/-/cli-plugin-router-4.5.6.tgz",
-      "integrity": "sha512-QEqOGglg0JEKddZPuyiSnAzAVK7IzLrdTPCUegigzGSbUXDW4gQiltY3/2nij2q538YvdIM7JXtW1sUfy4MgHQ==",
+      "version": "4.5.11",
+      "resolved": "https://registry.npmjs.org/@vue/cli-plugin-router/-/cli-plugin-router-4.5.11.tgz",
+      "integrity": "sha512-09tzw3faOs48IUPwLutYaNC7eoyyL140fKruTwdFdXuBLDdSQVida57Brx0zj2UKXc5qF8hk4GoGrOshN0KfNg==",
       "dev": true,
       "requires": {
-        "@vue/cli-shared-utils": "^4.5.6"
+        "@vue/cli-shared-utils": "^4.5.11"
       },
       "dependencies": {
         "@vue/cli-shared-utils": {
-          "version": "4.5.6",
-          "resolved": "https://registry.npmjs.org/@vue/cli-shared-utils/-/cli-shared-utils-4.5.6.tgz",
-          "integrity": "sha512-p6ePDlEa7Xc0GEt99KDOCwPZtR7UnoEaZLMfwPYU5LAWkdCmtAw8HPAY/WWcjtoiaAkY4k9tz7ZehQasZ9mJxg==",
+          "version": "4.5.11",
+          "resolved": "https://registry.npmjs.org/@vue/cli-shared-utils/-/cli-shared-utils-4.5.11.tgz",
+          "integrity": "sha512-+aaQ+ThQG3+WMexfSWNl0y6f43edqVqRNbguE53F3TIH81I7saS5S750ayqXhZs2r6STJJyqorQnKtAWfHo29A==",
           "dev": true,
           "requires": {
             "@hapi/joi": "^15.0.1",
@@ -3059,9 +3077,9 @@
       }
     },
     "@vue/cli-plugin-vuex": {
-      "version": "4.5.6",
-      "resolved": "https://registry.npmjs.org/@vue/cli-plugin-vuex/-/cli-plugin-vuex-4.5.6.tgz",
-      "integrity": "sha512-cWxj0jIhhupU+oFl0mc1St3ig9iF5F01XKwAhKEbvvuHR97zHxLd29My/vvcRwojZMy4aY320oJ+0ljoCIbueQ==",
+      "version": "4.5.11",
+      "resolved": "https://registry.npmjs.org/@vue/cli-plugin-vuex/-/cli-plugin-vuex-4.5.11.tgz",
+      "integrity": "sha512-JBPeZLubiSHbRkEKDj0tnLiU43AJ3vt6JULn4IKWH1XWZ6MFC8vElaP5/AA4O3Zko5caamDDBq3TRyxdA2ncUQ==",
       "dev": true
     },
     "@vue/cli-service": {
@@ -4607,9 +4625,9 @@
       },
       "dependencies": {
         "core-js": {
-          "version": "2.6.11",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.11.tgz",
-          "integrity": "sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg==",
+          "version": "2.6.12",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz",
+          "integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ==",
           "dev": true
         },
         "regenerator-runtime": {
@@ -5121,15 +5139,15 @@
       "dev": true
     },
     "bootstrap": {
-      "version": "4.5.3",
-      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-4.5.3.tgz",
-      "integrity": "sha512-o9ppKQioXGqhw8Z7mah6KdTYpNQY//tipnkxppWhPbiSWdD+1raYsnhwEZjkTHYbGee4cVQ0Rx65EhOY/HNLcQ==",
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-4.6.0.tgz",
+      "integrity": "sha512-Io55IuQY3kydzHtbGvQya3H+KorS/M9rSNyfCGCg9WZ4pyT/lCxIlpJgG1GXW/PswzC84Tr2fBYi+7+jFVQQBw==",
       "dev": true
     },
     "bootstrap-vue": {
-      "version": "2.19.0",
-      "resolved": "https://registry.npmjs.org/bootstrap-vue/-/bootstrap-vue-2.19.0.tgz",
-      "integrity": "sha512-IjAXUSrRU5Qu9x3uwUcoj6LtysKbCVeWoJOsODyI/WokStUr95M+tTIajXUjIrB/Nsk0fS+RNvZnm2sWeNFrhg==",
+      "version": "2.21.2",
+      "resolved": "https://registry.npmjs.org/bootstrap-vue/-/bootstrap-vue-2.21.2.tgz",
+      "integrity": "sha512-0Exe+4MZysqhZNXIKf4TzkvXaupxh9EHsoCRez0o5Dc0J7rlafayOEwql63qXv74CgZO8E4U8ugRNJko1vMvNw==",
       "dev": true,
       "requires": {
         "@nuxt/opencollective": "^0.3.2",
@@ -6153,9 +6171,9 @@
       "dev": true
     },
     "consola": {
-      "version": "2.15.0",
-      "resolved": "https://registry.npmjs.org/consola/-/consola-2.15.0.tgz",
-      "integrity": "sha512-vlcSGgdYS26mPf7qNi+dCisbhiyDnrN1zaRbw3CSuc2wGOMEGGPsp46PdRG5gqXwgtJfjxDkxRNAgRPr1B77vQ==",
+      "version": "2.15.3",
+      "resolved": "https://registry.npmjs.org/consola/-/consola-2.15.3.tgz",
+      "integrity": "sha512-9vAdYbHj6x2fLKC4+oPH0kFzY/orMZyG2Aj+kNylHxKGJ/Ed4dpNyAQYwJOdqO4zdM7XpVHmyejQDcQHrnuXbw==",
       "dev": true
     },
     "console-browserify": {
@@ -6296,9 +6314,9 @@
       }
     },
     "core-js": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.7.0.tgz",
-      "integrity": "sha512-NwS7fI5M5B85EwpWuIwJN4i/fbisQUwLwiSNUWeXlkAZ0sbBjLEvLvFLf1uzAUV66PcEPt4xCGCmOZSxVf3xzA==",
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.9.1.tgz",
+      "integrity": "sha512-gSjRvzkxQc1zjM/5paAmL4idJBFzuJoo+jDjF1tStYFMV2ERfD02HhahhCGXUyHxQRG4yFKVSdO6g62eoRMcDg==",
       "dev": true
     },
     "core-js-compat": {
@@ -6742,9 +6760,9 @@
       }
     },
     "dayjs": {
-      "version": "1.9.6",
-      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.9.6.tgz",
-      "integrity": "sha512-HngNLtPEBWRo8EFVmHFmSXAjtCX8rGNqeXQI0Gh7wCTSqwaKgPIDqu9m07wABVopNwzvOeCb+2711vQhDlcIXw==",
+      "version": "1.10.4",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.10.4.tgz",
+      "integrity": "sha512-RI/Hh4kqRc1UKLOAf/T5zdMMX5DQIlDxwUe3wSyMMnEbGunnpENCdbUgM+dW7kXidZqCttBrmw7BhN4TMddkCw==",
       "dev": true
     },
     "de-indent": {
@@ -7931,9 +7949,9 @@
       }
     },
     "eslint-plugin-prettier": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-3.1.4.tgz",
-      "integrity": "sha512-jZDa8z76klRqo+TdGDTFJSavwbnWK2ZpqGKNZ+VvweMW516pDUMmQ2koXvxEE4JhzNvTv+radye/bWGBmA6jmg==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-3.3.1.tgz",
+      "integrity": "sha512-Rq3jkcFY8RYeQLgk2cCwuc0P7SEFwDravPhsJZOQ5N4YI4DSg50NyqJ/9gdZHzQlHf8MvafSesbNJCcP/FF6pQ==",
       "dev": true,
       "requires": {
         "prettier-linter-helpers": "^1.0.0"
@@ -13487,9 +13505,9 @@
       }
     },
     "pretty-bytes": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-5.4.1.tgz",
-      "integrity": "sha512-s1Iam6Gwz3JI5Hweaz4GoCD1WUNUIyzePFy5+Js2hjwGVt2Z79wNN+ZKOZ2vB6C+Xs6njyB84Z1IthQg8d9LxA==",
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-5.6.0.tgz",
+      "integrity": "sha512-FFw039TmrBqFK8ma/7OL3sDz/VytdtJr044/QUJtH0wK9lb9jLq9tJyIxUwtQJHwar2BqtiA4iCWSwo9JLkzFg==",
       "dev": true
     },
     "pretty-error": {
@@ -13986,9 +14004,9 @@
       }
     },
     "register-service-worker": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/register-service-worker/-/register-service-worker-1.7.1.tgz",
-      "integrity": "sha512-IdTfUZ4u8iJL8o1w8es8l6UMGPmkwHolUdT+UmM1UypC80IB4KbpuIlvwWVj8UDS7eJwkEYRcKRgfRX+oTmJsw==",
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/register-service-worker/-/register-service-worker-1.7.2.tgz",
+      "integrity": "sha512-CiD3ZSanZqcMPRhtfct5K9f7i3OLCcBBWsJjLh1gW9RO/nS94sVzY59iS+fgYBOBqaBpf4EzfqUF3j9IG+xo8A==",
       "dev": true
     },
     "regjsgen": {
@@ -14570,9 +14588,9 @@
       "dev": true
     },
     "shvl": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/shvl/-/shvl-2.0.1.tgz",
-      "integrity": "sha512-VU7R5Uxp38LKHooGuZe0TcX2EPK95nn8DvclAvTPyD9/qHmXvt3dR2pJ4JLZ8uLjxQNQ3zNLFJCreteIj3cvpw==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/shvl/-/shvl-2.0.2.tgz",
+      "integrity": "sha512-G3KkIXPza3dgkt6Bo8zIl5K/KvAAhbG6o9KfAjhPvrIIzzAhnfc2ztv1i+iPTbNNM43MaBUqIaZwqVjkSgY/rw==",
       "dev": true
     },
     "signal-exit": {
@@ -16359,9 +16377,9 @@
       "dev": true
     },
     "vue-i18n": {
-      "version": "8.22.1",
-      "resolved": "https://registry.npmjs.org/vue-i18n/-/vue-i18n-8.22.1.tgz",
-      "integrity": "sha512-JNgiEJ5a8YPfk5y2lKyfOAGLmkpAVfhaUi+T4wGpSppRYZ3XSyawSDDketY5KV2CsAiBLAGEIO6jO+0l2hQubg==",
+      "version": "8.23.0",
+      "resolved": "https://registry.npmjs.org/vue-i18n/-/vue-i18n-8.23.0.tgz",
+      "integrity": "sha512-mXgniaumwca8tKdp55fmvqIcW658vQQXq0zEyRHp8sgZ6t+Md+Whhu6CCPg9/erVNlvpKzsGsucGjt2N8GrFCA==",
       "dev": true
     },
     "vue-loader": {
@@ -16416,9 +16434,9 @@
       }
     },
     "vue-router": {
-      "version": "3.4.9",
-      "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-3.4.9.tgz",
-      "integrity": "sha512-CGAKWN44RqXW06oC+u4mPgHLQQi2t6vLD/JbGRDAXm0YpMv0bgpKuU5bBd7AvMgfTz9kXVRIWKHqRwGEb8xFkA==",
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-3.5.1.tgz",
+      "integrity": "sha512-RRQNLT8Mzr8z7eL4p7BtKvRaTSGdCbTy2+Mm5HTJvLGYSSeG9gDzNasJPP/yOYKLy+/cLG/ftrqq5fvkFwBJEw==",
       "dev": true
     },
     "vue-style-loader": {
@@ -16477,19 +16495,19 @@
       }
     },
     "vuex": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/vuex/-/vuex-3.5.1.tgz",
-      "integrity": "sha512-w7oJzmHQs0FM9LXodfskhw9wgKBiaB+totOdb8sNzbTB2KDCEEwEs29NzBZFh/lmEK1t5tDmM1vtsO7ubG1DFw==",
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/vuex/-/vuex-3.6.2.tgz",
+      "integrity": "sha512-ETW44IqCgBpVomy520DT5jf8n0zoCac+sxWnn+hMe/CzaSejb/eVw2YToiXYX+Ex/AuHHia28vWTq4goAexFbw==",
       "dev": true
     },
     "vuex-persistedstate": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/vuex-persistedstate/-/vuex-persistedstate-3.1.0.tgz",
-      "integrity": "sha512-nRiCe1qDdDrcveFQzTw0QGEj3dRpwN19BailSSwfhe4eUNNQ+9S/ApKnDEAuyw95cigOtSPciMEhdsC0qNUiKQ==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/vuex-persistedstate/-/vuex-persistedstate-3.2.0.tgz",
+      "integrity": "sha512-1Q4zV9cNaJtl59jN6rXbndemEtXKywZr0OFZnqgpYdwvdyy+64KNsEltKldQW+i03st5LuDwHsdOEevXIZUgdg==",
       "dev": true,
       "requires": {
         "deepmerge": "^4.2.2",
-        "shvl": "^2.0.0"
+        "shvl": "^2.0.2"
       },
       "dependencies": {
         "deepmerge": {

--- a/package.json
+++ b/package.json
@@ -16,24 +16,24 @@
   },
   "devDependencies": {
     "@fortawesome/fontawesome-free": "5.8.2",
-    "@sentry/browser": "^5.27.3",
-    "@sentry/integrations": "^5.27.3",
-    "@types/node-fetch": "^2.5.7",
+    "@sentry/browser": "^5.30.0",
+    "@sentry/integrations": "^5.30.0",
+    "@types/node-fetch": "^2.5.8",
     "@vue/cli-plugin-babel": "^4.5.6",
     "@vue/cli-plugin-eslint": "~4.2.3",
-    "@vue/cli-plugin-pwa": "^4.5.6",
-    "@vue/cli-plugin-router": "^4.5.6",
-    "@vue/cli-plugin-vuex": "^4.5.6",
+    "@vue/cli-plugin-pwa": "^4.5.11",
+    "@vue/cli-plugin-router": "^4.5.11",
+    "@vue/cli-plugin-vuex": "^4.5.11",
     "@vue/cli-service": "~4.2.3",
     "@vue/eslint-config-prettier": "^6.0.0",
     "babel-eslint": "^10.0.3",
-    "bootstrap-vue": "^2.19.0",
-    "core-js": "^3.7.0",
+    "bootstrap-vue": "^2.21.2",
+    "core-js": "^3.9.1",
     "css-loader": "^3.6.0",
-    "dayjs": "^1.9.6",
+    "dayjs": "^1.10.4",
     "eslint": "^6.7.2",
     "eslint-config-prettier": "^6.15.0",
-    "eslint-plugin-prettier": "^3.1.4",
+    "eslint-plugin-prettier": "^3.3.1",
     "eslint-plugin-vue": "^6.1.2",
     "image-webpack-loader": "^6.0.0",
     "leaflet": "1.3.1",
@@ -42,20 +42,20 @@
     "lodash": "^4.17.20",
     "node-fetch": "^2.6.1",
     "prettier": "^2.1.2",
-    "register-service-worker": "^1.7.1",
+    "register-service-worker": "^1.7.2",
     "vue": "^2.6.12",
     "vue-analytics": "^5.22.1",
-    "vue-i18n": "^8.22.1",
+    "vue-i18n": "^8.23.0",
     "vue-mobile-detection": "^1.0.0",
     "vue-native-notification": "^1.1.1",
     "vue-notification": "^1.3.20",
     "vue-packery-plugin": "^1.4.8",
-    "vue-router": "^3.4.9",
+    "vue-router": "^3.5.1",
     "vue-template-compiler": "^2.6.12",
     "vue2-circle-progress": "^1.2.3",
     "vue2-leaflet": "^1.2.3",
-    "vuex": "^3.5.1",
-    "vuex-persistedstate": "^3.1.0"
+    "vuex": "^3.6.2",
+    "vuex-persistedstate": "^3.2.0"
   },
   "postcss": {
     "plugins": {
@@ -76,7 +76,9 @@
     "arrowParens": "always",
     "printWidth": 120
   },
-  "eslintIgnore": ["src/assets/**.*"],
+  "eslintIgnore": [
+    "src/assets/**.*"
+  ],
   "eslintConfig": {
     "root": true,
     "env": {
@@ -111,7 +113,12 @@
   ],
   "babel": {
     "presets": [
-      ["@vue/app", { "useBuiltIns": "entry" }]
+      [
+        "@vue/app",
+        {
+          "useBuiltIns": "entry"
+        }
+      ]
     ]
   }
 }

--- a/src/Notifier.js
+++ b/src/Notifier.js
@@ -166,12 +166,20 @@ const makeNotification = (type, data) => {
           icon: wfcdLogoUrl,
         },
       };
+    case 'arbitration':
+      return {
+        head: `Arbitration - ${data.node}`,
+        body: {
+          body: `${data.type}`,
+          icon: wfcdLogoUrl,
+        },
+      };
     default:
       return defaultNotificationBody;
   }
 };
 
-class Notifier {
+export default class Notifier {
   constructor(store) {
     this.store = store;
     this.notifier = Vue.notification;
@@ -329,6 +337,16 @@ class Notifier {
         toNotify.push(makeNotification('outposts', ws.sentientOutposts));
       }
     }
+
+    if (ws.arbitration) {
+      const id = `arbitration:${new Date(ws.arbitration.expiry).getTime()}`;
+      const notifId = `arbitration.${ws.arbitration.enemy.toLowerCase()}.${ws.arbitration.type
+        .toLowerCase()
+        .replace(/\s/gi, '')}`;
+      if (this.isNotifiable(id, notifId)) {
+        toNotify.push(makeNotification('arbitration', ws.arbitration));
+      }
+    }
     return toNotify;
   }
 
@@ -349,5 +367,3 @@ class Notifier {
     return this.store.dispatch('updateNotifiedIds');
   }
 }
-
-export default Notifier;

--- a/src/assets/json/components.json
+++ b/src/assets/json/components.json
@@ -234,6 +234,16 @@
       "sentientOutposts": "@worldstate.sentientOutposts"
     }
   },
+  "steelPath": {
+    "display": true,
+    "displayable": true,
+    "displayName": "Steel Path",
+    "key": "event",
+    "component": "SteelPathPanel",
+    "props": {
+      "events": "@worldstate.steelPath"
+    }
+  },
   "conclave": {
     "display": false,
     "displayable": true,

--- a/src/assets/json/components.json
+++ b/src/assets/json/components.json
@@ -1,6 +1,7 @@
 {
   "event": {
     "display": true,
+    "displayable": true,
     "displayName": "Events",
     "key": "event",
     "component": "EventsPanel",
@@ -9,7 +10,8 @@
     }
   },
   "acolytes": {
-    "display": true,
+    "display": false,
+    "displayable": false,
     "displayName": "Acolytes",
     "key": "acolytes",
     "component": "AcolytesPanel",
@@ -19,6 +21,7 @@
   },
   "cetus": {
     "display": true,
+    "displayable": true,
     "displayName": "Cetus Cycle",
     "key": "cetus",
     "component": "TimePanel",
@@ -29,6 +32,7 @@
   },
   "earth": {
     "display": true,
+    "displayable": true,
     "displayName": "Earth Cycle",
     "key": "earth",
     "component": "TimePanel",
@@ -39,6 +43,7 @@
   },
   "vallis": {
     "display": true,
+    "displayable": true,
     "displayName": "Vallis Cycle",
     "key": "vallis",
     "component": "TimePanel",
@@ -49,6 +54,7 @@
   },
   "cambion": {
     "display": true,
+    "displayable": true,
     "displayName": "Cambion Drift Cycle",
     "key": "cambion",
     "component": "TimePanel",
@@ -59,6 +65,7 @@
   },
   "bounties": {
     "display": true,
+    "displayable": true,
     "displayName": "Bounties Timer",
     "key": "bounties",
     "component": "BountyPanel",
@@ -69,6 +76,7 @@
   },
   "solaris-bounties": {
     "display": true,
+    "displayable": true,
     "displayName": "Solaris Bounties Timer",
     "key": "solaris-bounties",
     "component": "BountyPanel",
@@ -79,6 +87,7 @@
   },
   "entrati-bounties": {
     "display": true,
+    "displayable": true,
     "displayName": "Entrati Bounties Timer",
     "key": "entrati-bounties",
     "component": "BountyPanel",
@@ -89,6 +98,7 @@
   },
   "alerts": {
     "display": true,
+    "displayable": true,
     "displayName": "Alerts",
     "key": "alerts",
     "component": "AlertPanel",
@@ -98,6 +108,7 @@
   },
   "news": {
     "display": true,
+    "displayable": true,
     "displayName": "News",
     "key": "news",
     "component": "NewsPanel",
@@ -108,6 +119,7 @@
   },
   "invasions": {
     "display": true,
+    "displayable": true,
     "displayName": "Invasions",
     "key": "invasions",
     "component": "InvasionsPanel",
@@ -118,6 +130,7 @@
   },
   "reset": {
     "display": true,
+    "displayable": true,
     "displayName": "Reset Timer",
     "key": "reset",
     "component": "ResetPanel",
@@ -125,6 +138,7 @@
   },
   "sortie": {
     "display": true,
+    "displayable": true,
     "displayName": "Sortie",
     "key": "sortie",
     "component": "SortiePanel",
@@ -134,6 +148,7 @@
   },
   "arbitration": {
     "display": true,
+    "displayable": true,
     "displayName": "Arbitration",
     "key": "arbitration",
     "component": "ArbitrationPanel",
@@ -143,6 +158,7 @@
   },
   "fissures": {
     "display": true,
+    "displayable": true,
     "displayName": "Fissures",
     "key": "fissures",
     "component": "FissuresPanel",
@@ -151,7 +167,8 @@
     }
   },
   "kuvas": {
-    "display": true,
+    "display": false,
+    "displayable": false,
     "displayName": "Kuva Siphons",
     "key": "kuvas",
     "component": "KuvaPanel",
@@ -161,6 +178,7 @@
   },
   "baro": {
     "display": true,
+    "displayable": true,
     "displayName": "Void Trader",
     "key": "baro",
     "component": "VoidTraderPanel",
@@ -170,6 +188,7 @@
   },
   "darvo": {
     "display": true,
+    "displayable": true,
     "displayName": "Darvo Deals",
     "key": "darvo",
     "component": "DarvoDealsPanel",
@@ -179,6 +198,7 @@
   },
   "deals": {
     "display": false,
+    "displayable": true,
     "displayName": "Sales",
     "key": "deals",
     "component": "SalesPanel",
@@ -188,6 +208,7 @@
   },
   "nightwave": {
     "display": true,
+    "displayable": true,
     "displayName": "Nightwave",
     "key": "nightwave",
     "component": "NightwavePanel",
@@ -197,6 +218,7 @@
   },
   "construction": {
     "display": true,
+    "displayable": true,
     "displayName": "Construction",
     "key": "construction",
     "props": {
@@ -205,6 +227,7 @@
   },
   "sentientoutposts": {
     "display": true,
+    "displayable": true,
     "displayName": "Sentient Outposts",
     "key": "sentientoutposts",
     "props": {
@@ -213,6 +236,7 @@
   },
   "conclave": {
     "display": false,
+    "displayable": true,
     "displayName": "Conclave",
     "key": "conclave",
     "component": "ConclavePanel",

--- a/src/assets/json/trackables.json
+++ b/src/assets/json/trackables.json
@@ -175,12 +175,12 @@
     "cetus.day": {
       "state": false,
       "value": "cetus.day",
-      "text": "Cetus' Day Start"
+      "text": "Cetus Day Start"
     },
     "cetus.night": {
       "state": false,
       "value": "cetus.night",
-      "text": "Cetus' Night Start"
+      "text": "Cetus Night Start"
     },
     "syndicate.ostrons": {
       "state": false,
@@ -476,6 +476,181 @@
       "state": false,
       "value": "fissures.t5.survival",
       "text": "Requiem Survival Fissure"
+    },
+    "arbitration.grineer.excavation": {
+      "state": false,
+      "value": "arbitration.grineer.excavation",
+      "text": "Grineer Excavation Arbitration"
+    },
+    "arbitration.corpus.excavation": {
+      "state": false,
+      "value": "arbitration.corpus.excavation",
+      "text": "Corpus Excavation Arbitration"
+    },
+    "arbitration.corrupted.excavation": {
+      "state": false,
+      "value": "arbitration.corrupted.excavation",
+      "text": "Corrupted Excavation Arbitration"
+    },
+    "arbitration.orokin.excavation": {
+      "state": false,
+      "value": "arbitration.orokin.excavation",
+      "text": "Orokin Excavation Arbitration"
+    },
+    "arbitration.infested.excavation": {
+      "state": false,
+      "value": "arbitration.infested.excavation",
+      "text": "Infested Excavation Arbitration"
+    },
+    "arbitration.grineer.defense": {
+      "state": false,
+      "value": "arbitration.grineer.defense",
+      "text": "Grineer Defense Arbitration"
+    },
+    "arbitration.corpus.defense": {
+      "state": false,
+      "value": "arbitration.corpus.defense",
+      "text": "Corpus Defense Arbitration"
+    },
+    "arbitration.corrupted.defense": {
+      "state": false,
+      "value": "arbitration.corrupted.defense",
+      "text": "Corrupted Defense Arbitration"
+    },
+    "arbitration.orokin.defense": {
+      "state": false,
+      "value": "arbitration.orokin.defense",
+      "text": "Orokin Defense Arbitration"
+    },
+    "arbitration.infested.defense": {
+      "state": false,
+      "value": "arbitration.infested.defense",
+      "text": "Infested Defense Arbitration"
+    },
+    "arbitration.grineer.disruption": {
+      "state": false,
+      "value": "arbitration.grineer.disruption",
+      "text": "Grineer Disruption Arbitration"
+    },
+    "arbitration.corpus.disruption": {
+      "state": false,
+      "value": "arbitration.corpus.disruption",
+      "text": "Corpus Disruption Arbitration"
+    },
+    "arbitration.corrupted.disruption": {
+      "state": false,
+      "value": "arbitration.corrupted.disruption",
+      "text": "Corrupted Disruption Arbitration"
+    },
+    "arbitration.orokin.disruption": {
+      "state": false,
+      "value": "arbitration.orokin.disruption",
+      "text": "Orokin Disruption Arbitration"
+    },
+    "arbitration.infested.disruption": {
+      "state": false,
+      "value": "arbitration.infested.disruption",
+      "text": "Infested Disruption Arbitration"
+    },
+    "arbitration.grineer.survival": {
+      "state": false,
+      "value": "arbitration.grineer.survival",
+      "text": "Grineer Survival Arbitration"
+    },
+    "arbitration.corpus.survival": {
+      "state": false,
+      "value": "arbitration.corpus.survival",
+      "text": "Corpus Survival Arbitration"
+    },
+    "arbitration.corrupted.survival": {
+      "state": false,
+      "value": "arbitration.corrupted.survival",
+      "text": "Corrupted Survival Arbitration"
+    },
+    "arbitration.orokin.survival": {
+      "state": false,
+      "value": "arbitration.orokin.survival",
+      "text": "Orokin Survival Arbitration"
+    },
+    "arbitration.infested.survival": {
+      "state": false,
+      "value": "arbitration.infested.survival",
+      "text": "Infested Survival Arbitration"
+    },
+    "arbitration.grineer.defection": {
+      "state": false,
+      "value": "arbitration.grineer.defection",
+      "text": "Grineer Defection Arbitration"
+    },
+    "arbitration.corpus.defection": {
+      "state": false,
+      "value": "arbitration.corpus.defection",
+      "text": "Corpus Defection Arbitration"
+    },
+    "arbitration.corrupted.defection": {
+      "state": false,
+      "value": "arbitration.corrupted.defection",
+      "text": "Corrupted Defection Arbitration"
+    },
+    "arbitration.orokin.defection": {
+      "state": false,
+      "value": "arbitration.orokin.defection",
+      "text": "Orokin Defection Arbitration"
+    },
+    "arbitration.infested.defection": {
+      "state": false,
+      "value": "arbitration.infested.defection",
+      "text": "Infested Defection Arbitration"
+    },
+    "arbitration.grineer.infestedsalvage": {
+      "state": false,
+      "value": "arbitration.grineer.infestedsalvage",
+      "text": "Grineer Infested Salvage Arbitration"
+    },
+    "arbitration.corpus.infestedsalvage": {
+      "state": false,
+      "value": "arbitration.corpus.infestedsalvage",
+      "text": "Corpus Infested Salvage Arbitration"
+    },
+    "arbitration.corrupted.infestedsalvage": {
+      "state": false,
+      "value": "arbitration.corrupted.infestedsalvage",
+      "text": "Corrupted Infested Salvage Arbitration"
+    },
+    "arbitration.orokin.infestedsalvage": {
+      "state": false,
+      "value": "arbitration.orokin.infestedsalvage",
+      "text": "Orokin Infested Salvage Arbitration"
+    },
+    "arbitration.infested.infestedsalvage": {
+      "state": false,
+      "value": "arbitration.infested.infestedsalvage",
+      "text": "Infested Infested Salvage Arbitration"
+    },
+    "arbitration.grineer.interception": {
+      "state": false,
+      "value": "arbitration.grineer.interception",
+      "text": "Grineer Interception Arbitration"
+    },
+    "arbitration.corpus.interception": {
+      "state": false,
+      "value": "arbitration.corpus.interception",
+      "text": "Corpus Interception Arbitration"
+    },
+    "arbitration.corrupted.interception": {
+      "state": false,
+      "value": "arbitration.corrupted.interception",
+      "text": "Corrupted Interception Arbitration"
+    },
+    "arbitration.orokin.interception": {
+      "state": false,
+      "value": "arbitration.orokin.interception",
+      "text": "Orokin Interception Arbitration"
+    },
+    "arbitration.infested.interception": {
+      "state": false,
+      "value": "arbitration.infested.interception",
+      "text": "Infested Interception Arbitration"
     }
   }
 }

--- a/src/components/TimeBadge.vue
+++ b/src/components/TimeBadge.vue
@@ -64,7 +64,7 @@ export default {
       }
       if (timeText.includes('-')) {
         this.$parent.$forceUpdate();
-        timeText = `-${timeText.replace(/\-/g, '')}`;
+        timeText = `-${timeText.replace(/-/g, '')}`;
       }
       return timeText;
     },

--- a/src/components/TimeBadge.vue
+++ b/src/components/TimeBadge.vue
@@ -64,6 +64,7 @@ export default {
       }
       if (timeText.includes('-')) {
         this.$parent.$forceUpdate();
+        timeText = `-${timeText.replace(/\-/g, '')}`;
       }
       return timeText;
     },

--- a/src/components/modalDialogs/Settings.vue
+++ b/src/components/modalDialogs/Settings.vue
@@ -60,6 +60,8 @@ import Platforms from '@/components/modalDialogs/Platforms.vue';
 import Languages from '@/components/modalDialogs/Languages.vue';
 
 import themes from '@/assets/json/themes.json';
+import baseComponents from '@/assets/json/components.json';
+
 export default {
   name: 'SettingsModal',
   components: {
@@ -102,18 +104,28 @@ export default {
         const components = Object.keys(this.$store.getters.componentState).map(
           (component) => this.$store.getters.componentState[component]
         );
-        return components.filter((component) => component.display).map((component) => component.key);
+        return components
+          .filter(
+            (component) =>
+              component.display && (!baseComponents[component.key] || baseComponents[component.key].displayable)
+          )
+          .map((component) => component.key);
       },
       set: function () {},
     },
     componentStates() {
       const cs = this.$store.getters.componentState;
-      return Object.keys(cs).map((component) => {
-        return {
-          text: this.$store.getters.componentState[component].displayName,
-          value: this.$store.getters.componentState[component].key,
-        };
-      });
+      return Object.keys(cs)
+        .map((component) => {
+          if (!baseComponents[component] || !baseComponents[component].displayable) {
+            return false;
+          }
+          return {
+            text: this.$store.getters.componentState[component].displayName,
+            value: this.$store.getters.componentState[component].key,
+          };
+        })
+        .filter((c) => c);
     },
     getComponents() {
       return this.$store.getters.componentState;

--- a/src/components/panels/EventsPanel.vue
+++ b/src/components/panels/EventsPanel.vue
@@ -108,21 +108,12 @@
           </b-badge>
         </div>
 
-        <div
-          class="text-center bottom-pad"
-          v-if="event.altActivation !== '1970-01-01T00:00:00.000Z' && event.altExpiry !== '1970-01-01T00:00:00.000Z'"
-        >
+        <div class="text-center bottom-pad" v-if="event.altActivation !== epoch && event.altExpiry !== epoch">
           <div>{{ $t('events.currentCycle') }}</div>
           <TimeBadge :starttime="event.altActivation" :endtime="event.altExpiry" :interval="1000" :pullright="false" />
         </div>
 
-        <div
-          class="text-center bottom-pad"
-          :if="
-            event.nextAlt.activation !== '1970-01-01T00:00:00.000Z' &&
-            event.nextAlt.expiry !== '1970-01-01T00:00:00.000Z'
-          "
-        >
+        <div class="text-center bottom-pad" v-if="event.nextAlt.activation !== epoch && event.nextAlt.expiry !== epoch">
           <div>{{ $t('events.nextCycle') }}</div>
           <TimeBadge
             :starttime="event.nextAlt.activation"
@@ -147,6 +138,7 @@ import standing from '@/assets/img/general/standing.svg';
 
 import util from '@/utilities';
 
+const epoch = '1970-01-01T00:00:00.000Z';
 const reversedHealthEvents = ['Thermia Fractures'];
 
 export default {
@@ -170,6 +162,7 @@ export default {
         },
       ],
       standing: standing,
+      epoch: epoch,
     };
   },
   computed: {

--- a/src/components/panels/SentientOutpostsPanel.vue
+++ b/src/components/panels/SentientOutpostsPanel.vue
@@ -7,7 +7,9 @@
             id="para_tooltip"
             :src="sentient"
             :name="this.$t('factions.sentient') + ' | ' + this.$t('sentientoutpost.warn')"
-            :style="factionImg" width="20px" height="20px"
+            :style="factionImg"
+            width="20px"
+            height="20px"
           />
           {{ sentientOutposts.mission.node }}
         </span>

--- a/src/components/panels/SentientOutpostsPanel.vue
+++ b/src/components/panels/SentientOutpostsPanel.vue
@@ -3,12 +3,13 @@
     <b-list-group>
       <b-list-group-item class="list-group-item-borderbottom" v-if="sentientOutposts.active">
         <span class="pull-left">
-          <HubImg :src="sentient" :name="this.$t('factions.sentient')" :style="factionImg" width="20px" height="20px" />
-          <b>{{ sentientOutposts.mission.node }}</b> - {{ sentientOutposts.mission.faction }}
-          <i id="para_tooltip" class="fa-xs fas fa-exclamation-triangle"></i>
-          <b-tooltip target="para_tooltip" placement="top" class="text-center">
-            {{ $t('sentientoutpost.warn') }}
-          </b-tooltip>
+          <HubImg
+            id="para_tooltip"
+            :src="sentient"
+            :name="this.$t('factions.sentient') + ' | ' + this.$t('sentientoutpost.warn')"
+            :style="factionImg" width="20px" height="20px"
+          />
+          {{ sentientOutposts.mission.node }}
         </span>
         <TimeBadge :starttime="sentientOutposts.activation" :endtime="sentientOutposts.expiry" :interval="1000" />
       </b-list-group-item>

--- a/src/components/panels/TimePanel.vue
+++ b/src/components/panels/TimePanel.vue
@@ -1,5 +1,5 @@
 <template>
-  <HubPanelWrap :title="headertext" class="time" :class="[location.toLowerCase()]">
+  <HubPanelWrap :title="headertext" class="time" :class="[(location || 'sol').toLowerCase()]">
     <b-list-group>
       <b-list-group-item :style="styleObject" class="list-group-item-borderbottom">
         <div class="row">
@@ -16,12 +16,14 @@
               }"
             >
               <span style="text-transform: capitalize">{{
-                this.$t(`time.${(time.state || time.active).toLowerCase()}`)
+                time.state || time.active
+                  ? this.$t(`time.${(time.state || time.active).toLowerCase()}`)
+                  : display
               }}</span>
             </span>
           </div>
           <div class="col-md-3">
-            <TimeBadge :starttime="now" :endtime="time.expiry" :interval="1000" />
+            <TimeBadge :starttime="time.activation || now" :endtime="time.expiry" :interval="1000" />
           </div>
         </div>
       </b-list-group-item>
@@ -35,14 +37,16 @@ import dayjs from 'dayjs';
 import HubPanelWrap from '@/components/HubPanelWrap';
 
 export default {
-  props: ['time', 'location'],
+  props: ['time', 'location', 'display', 'headerPath'],
   name: 'TimePanel',
   computed: {
     now() {
       return dayjs().toISOString();
     },
     headertext() {
-      return `${this.$t(`location.${this.$props.location.toLowerCase()}`)} ${this.$t('time.Timer')}`;
+      return this.$props.headerPath
+        ?  this.$t(this.$props.headerPath)
+        : `${this.$t(`location.${this.$props.location.toLowerCase()}`)} ${this.$t('time.Timer')}`;
     },
   },
   components: {

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -147,6 +147,9 @@
   "sortie": {
     "header": "Sortie"
   },
+  "steelPath": {
+    "header": "Steel Path"
+  },
   "time": {
     "loading": "Loading...",
     "day": "day",

--- a/src/store.js
+++ b/src/store.js
@@ -165,7 +165,8 @@ const actions = {
       .concat(ws.conclaveChallenges.map((item) => item.id))
       .concat([ws.cetusCycle.id])
       .concat([ws.voidTrader.id])
-      .concat(ws.persistentEnemies.map((enemy) => enemy.pid))
+      .concat([`arbitration:${new Date(ws.arbitration.expiry).getTime()}`])
+      // .concat(ws.persistentEnemies.map((enemy) => enemy.pid))
       .concat((ws.nightwave || { activeChallenges: [] }).activeChallenges.map((challenge) => challenge.id))
       .concat([ws.sentientOutposts.id]);
     commit('notifiedIds', [newIds]);
@@ -201,7 +202,7 @@ const getters = {
 
 Vue.use(Vuex);
 const shouldPersist = (process.env.VUE_APP_PERSIST === undefined ? 'true' : process.env.VUE_APP_PERSIST) === 'true';
-var tStore;
+let tStore;
 if (shouldPersist) {
   tStore = new Vuex.Store({
     state,

--- a/src/views/Timer.vue
+++ b/src/views/Timer.vue
@@ -6,6 +6,12 @@
         <timer v-if="componentState.cetus.display" :time="worldstate.cetusCycle" location="Cetus" />
         <timer v-if="componentState.vallis.display" :time="worldstate.vallisCycle" location="Vallis" />
         <timer v-if="componentState.cambion.display" :time="worldstate.cambionCycle" location="Cambion" />
+        <timer
+          v-if="componentState.steelPath.display"
+          :time="worldstate.steelPath"
+          :display="worldstate.steelPath.currentReward"
+          headerPath="steelPath.header"
+        />
         <sentientOutposts
           v-if="componentState.sentientoutposts.display"
           :sentientOutposts="worldstate.sentientOutposts"

--- a/src/views/Timer.vue
+++ b/src/views/Timer.vue
@@ -14,8 +14,11 @@
         <construction v-if="componentState.construction.display" :construction="worldstate.constructionProgress" />
         <deals v-if="componentState.darvo.display" :deals="worldstate.dailyDeals" />
         <news v-if="componentState.news.display" :news="worldstate.news" />
-        <acolytes v-if="componentState.acolytes.display" :acolytes="worldstate.persistentEnemies" />
-        <events v-if="componentState.event.display" :events="worldstate.events" />
+        <!-- <acolytes v-if="componentState.acolytes.display" :acolytes="worldstate.persistentEnemies" /> -->
+        <events
+          v-if="componentState.event.display && worldstate.events && worldstate.events.length"
+          :events="worldstate.events"
+        />
         <alerts v-if="componentState.alerts.display" :alerts="worldstate.alerts" />
         <invasions v-if="componentState.invasions.display" :invasions="worldstate.invasions" />
         <nightwave v-if="componentState.nightwave.display" :nightwave="worldstate.nightwave" />
@@ -23,7 +26,7 @@
         <sortie v-if="componentState.sortie.display" :sortie="worldstate.sortie" />
         <arbitration v-if="componentState.arbitration.display" :arbitration="worldstate.arbitration" />
         <fissures v-if="componentState.fissures.display" :fissures="worldstate.fissures" />
-        <kuvas v-if="componentState.kuvas.display" :kuvas="worldstate.kuva" />
+        <!-- <kuvas v-if="componentState.kuvas.display" :kuvas="worldstate.kuva" /> -->
         <bounty v-if="componentState.bounties.display" :syndicate="ostron" type="ostron" />
         <bounty v-if="componentState['solaris-bounties'].display" :syndicate="solaris" type="solaris" />
         <bounty v-if="componentState['entrati-bounties'].display" :syndicate="entrati" type="entrati" />
@@ -42,9 +45,9 @@ import TimePanel from '@/components/panels/TimePanel.vue';
 import ResetPanel from '@/components/panels/ResetPanel.vue';
 import SortiePanel from '@/components/panels/SortiePanel.vue';
 import ArbitrationPanel from '@/components/panels/ArbitrationPanel.vue';
-import AcolytesPanel from '@/components/panels/AcolytesPanel.vue';
+// import AcolytesPanel from '@/components/panels/AcolytesPanel.vue';
 import FissuresPanel from '@/components/panels/FissuresPanel.vue';
-import KuvaPanel from '@/components/panels/KuvaPanel.vue';
+// import KuvaPanel from '@/components/panels/KuvaPanel.vue';
 import BountyPanel from '@/components/panels/BountyPanel.vue';
 import InvasionsPanel from '@/components/panels/InvasionsPanel.vue';
 import EventsPanel from '@/components/panels/EventsPanel.vue';
@@ -65,9 +68,9 @@ export default {
     reset: ResetPanel,
     sortie: SortiePanel,
     arbitration: ArbitrationPanel,
-    acolytes: AcolytesPanel,
+    // acolytes: AcolytesPanel,
     fissures: FissuresPanel,
-    kuvas: KuvaPanel,
+    // kuvas: KuvaPanel,
     bounty: BountyPanel,
     invasions: InvasionsPanel,
     events: EventsPanel,


### PR DESCRIPTION
**Summary:**
- turn off kuva & acolytes
- clean up outpost text, put more info in hover, less in one line
- add the ability to turn off components globally without needing to 
force a full store wipe
- clean up lots of negatives in expired time badges
- autohide events if there're no events

---
**Fixes issue (include link):**
closes #448 
- discord reported [multiple negatives](https://cdn.discordapp.com/attachments/372476825596723210/790581798434373642/Capture_2020-12-21-15-09-09.png)

---
**Mockups, screenshots, evidence:**


