### PR TITLE
Czech & Serbian locale support

### DIFF
--- a/.env
+++ b/.env
@@ -1,2 +1,4 @@
 # Public DSN, no issue to include it in scm
 VUE_APP_DSN=https://0fa0b9c182264f3aaec6749f2a657927@sentry.io/1851598
+VUE_APP_ANALYICS_URL=https://stats.warframestat.us/
+VUE_APP_ANALYICS_SITE=3

--- a/src/assets/json/locales.json
+++ b/src/assets/json/locales.json
@@ -1,4 +1,8 @@
 {
+  "cs": {
+    "display": "Čeština",
+    "key": "cs"
+  },
   "en": {
     "display": "English",
     "key": "en"
@@ -30,6 +34,10 @@
   "pt": {
     "display": "Português",
     "key": "pt"
+  },
+  "sr": {
+    "display": "Srpski",
+    "key": "sr"
   },
   "ru": {
     "display": "Pусский",

--- a/src/main.js
+++ b/src/main.js
@@ -49,13 +49,12 @@ Vue.use(Notifications);
 
 /* Analytics */
 import VueMatomo from 'vue-matomo';
-if (process.env.NODE_ENV === 'production' && process.env.VUE_APP_ANALYICS_URL) {
+if (process.env.VUE_APP_ANALYICS_URL) {
   Vue.use(VueMatomo, {
     host: process.env.VUE_APP_ANALYICS_URL,
     siteId: process.env.VUE_APP_ANALYICS_SITE,
     router: router,
     enableLinkTracking: true,
-    requireConsent: true,
     disableCookies: true,
     enableHeartBeatTimer: true,
     debug: process.env.NODE_ENV !== 'production',


### PR DESCRIPTION
**Summary:** Add hub support for serbian & czech locales
Note: the worldstate data itself doesn't have full support (yet) for these, so they'll still display in English until more data is added upstream

---
**Fixes issue (include link):** N/A


---
**Mockups, screenshots, evidence:**


