### PR TITLE
fix: leverage language query string for API

### DIFF
--- a/store/cache.js
+++ b/store/cache.js
@@ -30,24 +30,24 @@ export const actions = {
     commit('commitRivens', [rootGetters['worldstate/platform'], rivens]);
   },
   async updateSynthData({ commit }) {
-    const res = await get('https://api.warframestat.us/synthTargets');
+    const res = await get(`https://api.warframestat.us/synthTargets&language=${rootGetters['worldstate/platform']}`);
     safeCommit(commit, 'commitSynthData', res);
   },
   async updateWarframes({ commit }) {
     const res = await get(
-      'https://api.warframestat.us/warframes?exclude=category,color,conclave,patchlogs,wikiaThumbnail,type,tradable'
+      `https://api.warframestat.us/warframes?exclude=category,color,conclave,patchlogs,wikiaThumbnail,type,tradable&language=${rootGetters['worldstate/locale']}`
     );
     safeCommit(commit, 'commitFrameData', res);
   },
   async updateWeapons({ commit }) {
     const res = await get(
-      'https://api.warframestat.us/weapons?exclude=category,color,conclave,patchlogs,wikiaThumbnail,type,tradable'
+      `https://api.warframestat.us/weapons?exclude=category,color,conclave,patchlogs,wikiaThumbnail,type,tradable&language=${rootGetters['worldstate/locale']}`
     );
     safeCommit(commit, 'commitWeaponData', res);
   },
   async updateMods({ commit }) {
     const res = await get(
-      'https://api.warframestat.us/mods?exclude=category,color,conclave,patchlogs,wikiaThumbnail,type,tradable'
+      `https://api.warframestat.us/mods?exclude=category,color,conclave,patchlogs,wikiaThumbnail,type,tradable&language=${rootGetters['worldstate/locale']}`
     );
     safeCommit(commit, 'commitModData', res);
   },

--- a/store/cache.js
+++ b/store/cache.js
@@ -29,23 +29,23 @@ export const actions = {
     const rivens = JSON.parse(raw.replace(/NaN/g, 0).replace(/WARNING:.*\n/, ''));
     commit('commitRivens', [rootGetters['worldstate/platform'], rivens]);
   },
-  async updateSynthData({ commit }) {
+  async updateSynthData({ commit, rootGetters }) {
     const res = await get(`https://api.warframestat.us/synthTargets&language=${rootGetters['worldstate/platform']}`);
     safeCommit(commit, 'commitSynthData', res);
   },
-  async updateWarframes({ commit }) {
+  async updateWarframes({ commit, rootGetters }) {
     const res = await get(
       `https://api.warframestat.us/warframes?exclude=category,color,conclave,patchlogs,wikiaThumbnail,type,tradable&language=${rootGetters['worldstate/locale']}`
     );
     safeCommit(commit, 'commitFrameData', res);
   },
-  async updateWeapons({ commit }) {
+  async updateWeapons({ commit, rootGetters }) {
     const res = await get(
       `https://api.warframestat.us/weapons?exclude=category,color,conclave,patchlogs,wikiaThumbnail,type,tradable&language=${rootGetters['worldstate/locale']}`
     );
     safeCommit(commit, 'commitWeaponData', res);
   },
-  async updateMods({ commit }) {
+  async updateMods({ commit, rootGetters }) {
     const res = await get(
       `https://api.warframestat.us/mods?exclude=category,color,conclave,patchlogs,wikiaThumbnail,type,tradable&language=${rootGetters['worldstate/locale']}`
     );

--- a/store/worldstate.js
+++ b/store/worldstate.js
@@ -140,7 +140,7 @@ export const mutations = {
 export const actions = {
   async updateWorldstate(context) {
     const { commit, getters } = context;
-    const ws = await get(`${apiBase}/${getters.platform}`, {
+    const ws = await get(`${apiBase}/${getters.platform}?language=${getters.locale}`, {
       headers: {
         'Accept-Language': getters.locale,
       },


### PR DESCRIPTION
**Summary:**
recent caching additions for the worldstate have caused some weird issues for languages that are anything requested after the first one in a limited period

---
**Fixes issue (include link):**


---
**Mockups, screenshots, evidence:**


