### PR TITLE
fix: image name for synthesis from imageKey

### DIFF
--- a/components/SynthesisImg.vue
+++ b/components/SynthesisImg.vue
@@ -7,6 +7,8 @@
 import HubImg from '@/components/HubImg';
 import { optimize, cdn } from '@/services/utilities';
 
+const translate = (stub) => (stub ? optimize(cdn(`webp/synthesis/${stub}.webp`)) : null);
+
 const imgs = {
   'Ancient Disruptor': optimize(cdn('webp/synthesis/ancient_disruptor.webp')),
   'Ancient Healer': optimize(cdn('webp/synthesis/ancient_healer.webp')),
@@ -67,11 +69,12 @@ export default {
       type: String,
       default: '100px',
     },
+    image: { type: String, required: true },
   },
   data() {
     return {
       target: this.name,
-      src: imgs[this.name],
+      src: translate(this.image) || imgs[this.name],
     };
   },
 };

--- a/pages/synthesis.vue
+++ b/pages/synthesis.vue
@@ -65,7 +65,7 @@
           {{ datum.item.name }}
         </template>
         <template #cell(portrait)="datum">
-          <SynthesisImg :name="datum.item.name" />
+          <SynthesisImg :name="datum.item.name" :image="datum.item.imageKey" />
         </template>
         <template #cell(location)="datum">
           <span v-for="(location, key) in datum.item.locations" :key="key">


### PR DESCRIPTION
**Summary:**
Leverage imageKey in synthesis data for finding synthesis target image

---
**Fixes issue (include link):**
closes #796

---
**Mockups, screenshots, evidence:**

![image](https://user-images.githubusercontent.com/7128721/172250812-a9ed81ae-a665-4d14-805b-b1b6973a35fb.png)

