### PR TITLE
fix: various BountyPanel bugs

### DIFF
--- a/components/panels/BountyPanel.vue
+++ b/components/panels/BountyPanel.vue
@@ -155,5 +155,6 @@ export default {
 }
 .table {
   margin-bottom: 0.5em;
+  user-select: none;
 }
 </style>

--- a/components/panels/BountyPanel.vue
+++ b/components/panels/BountyPanel.vue
@@ -14,7 +14,7 @@
         >
           <template #cell(type)="data">
             <div>
-              <div size="sm" class="ml-2 pull-left" @click="data.toggleDetails">
+              <div size="sm" class="ml-2 pull-left">
                 <i v-if="data.detailsShowing" class="fas fa-chevron-down"></i>
                 <i v-else class="fas fa-chevron-right"></i>
               </div>

--- a/components/panels/BountyPanel.vue
+++ b/components/panels/BountyPanel.vue
@@ -33,12 +33,6 @@
           <template #cell(standing)="row">
             {{ row.item.standing }}
           </template>
-          <template #cell(moreinfo)="row">
-            <div size="sm" class="mr-2" @click="row.toggleDetails">
-              <i v-if="row.detailsShowing" class="fas fa-chevron-down"></i>
-              <i v-else class="fas fa-chevron-right"></i>
-            </div>
-          </template>
           <template #row-details="row">
             <span>
               <b-badge v-for="(reward, index) in row.item.rewards" :key="`reward-${type}-${index}`">{{


### PR DESCRIPTION
**Summary:**

This includes the following fixes for bounty panels:
- Directly clicking on the chevron in a table row now correctly expands and closes the details.
- Rapidly clicking on table rows now expands and closes the details instead of selecting the text.
  - *I tried preserving text selection in detail rows, but for some reason, the entire table becomes unresponsive when there's an active selection in a detail row.*

Neither feat nor fix:
- An unused table slot in BountyPanel has been removed.

---
**Mockups, screenshots, evidence:**

Footage of the chevron click bug:
https://github.com/WFCD/warframe-hub/assets/65450174/2a836213-7e05-4a8e-bdab-d56c61914f79
