### PR TITLE
fix: steel essence image missing

### DIFF
--- a/components/panels/AggregatedTimePanel.jsx
+++ b/components/panels/AggregatedTimePanel.jsx
@@ -3,6 +3,7 @@ import utc from 'dayjs/plugin/utc';
 import { mapState } from 'vuex';
 import TimeBadge from '@/components/TimeBadge.jsx';
 
+import thumb from '@/components/AsyncItemThumb.jsx';
 import HubPanelWrap from '@/components/HubPanelWrap.jsx';
 import HubImg from '@/components/HubImg.jsx';
 
@@ -11,7 +12,6 @@ import { cdn, wfcdn, optimize } from '@/services/utilities.js';
 dayjs.extend(utc);
 
 const steelPath = cdn('svg/sp-logo.svg');
-const steelEssence = optimize(wfcdn('steel-essence.png'), '250x250', 'fill', 'center');
 
 const cycleDefault = {
   activation: '0',
@@ -254,7 +254,7 @@ const SteelPathTimer = {
         </span>
         <br />
         {this.steelPath?.currentReward?.cost}
-        <HubImg src={steelEssence} name={this.$t('currency.steelEssense')} />
+        <thumb ikey={'Steel Essence'} alt={this.$t('currency.steelEssense')} />
         <br />
         <TimeBadge
           starttime={this.steelPath?.activation || '0'}


### PR DESCRIPTION
**Summary:**
try to fix missing steel essence image

---
**Fixes issue (include link):**


---
**Mockups, screenshots, evidence:**




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the Steel Essence display from an image to a component representation for improved visual consistency.
  
- **Bug Fixes**
	- No bugs reported; existing timer functionalities remain intact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->