### PR TITLE
fix: turn off earth state panel

### DIFF
--- a/components/panels/AggregatedTimePanel.jsx
+++ b/components/panels/AggregatedTimePanel.jsx
@@ -373,7 +373,7 @@ export default {
           <b-list-group-item class="list-group-item-borderbottom">
             <b-container>
               <b-row class="justify-content-center">
-                {this.componentState.earth.display && <EarthTimer earthCycle={this.worldstate.earthCycle} />}
+                {false && <EarthTimer earthCycle={this.worldstate.earthCycle} />}
                 {this.componentState.cetus.display && <CetusTimer cetusCycle={this.worldstate.cetusCycle} />}
                 {this.componentState.vallis.display && <VallisTimer vallisCycle={this.worldstate.vallisCycle} />}
                 {this.componentState.cambion.display && <CambionTimer cambionCycle={this.worldstate.cambionCycle} />}


### PR DESCRIPTION
**Summary:**
earth & cetus timers merged in 38.5.0

![image](https://github.com/user-attachments/assets/915bad16-3d6b-458a-8bae-f9b063e620f7)

---
**Fixes issue (include link):**


---
**Mockups, screenshots, evidence:**




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated the time panel display to remove an unnecessary timer element, streamlining the view to show only the relevant timers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->