### PR TITLE
fix: turn off earth state panel

### DIFF
--- a/components/panels/AggregatedTimePanel.jsx
+++ b/components/panels/AggregatedTimePanel.jsx
@@ -44,41 +44,6 @@ const TimerPanel = {
   },
 };
 
-const EarthTimer = {
-  props: ['earthCycle'],
-  computed: {
-    isEarthDay() {
-      return this.$props.earthCycle.isDay;
-    },
-    isEarthNight() {
-      return !this.$props.earthCycle.isDay;
-    },
-    now() {
-      return dayjs().toISOString();
-    },
-  },
-  render() {
-    return (
-      <TimerPanel>
-        <span style={textStyle}>
-          {this.$t(`location.earth`)}
-          <br />
-          {this.isEarthDay && <i class="fa fa-sun fa-2x day" style={textStyle}></i>}
-          {this.isEarthNight && <i class="fa fa-moon fa-2x night" style={textStyle}></i>}
-          <br />
-          {this.$t(`time.${this.earthCycle.state.toLowerCase()}`)}
-        </span>
-        <br />
-        <TimeBadge
-          starttime={this.earthCycle.activation || this.now}
-          endtime={this.earthCycle.expiry}
-          interval={1000}
-          pullright={false}
-        />
-      </TimerPanel>
-    );
-  },
-};
 const CetusTimer = {
   props: ['cetusCycle'],
   computed: {
@@ -373,7 +338,6 @@ export default {
           <b-list-group-item class="list-group-item-borderbottom">
             <b-container>
               <b-row class="justify-content-center">
-                {false && <EarthTimer earthCycle={this.worldstate.earthCycle} />}
                 {this.componentState.cetus.display && <CetusTimer cetusCycle={this.worldstate.cetusCycle} />}
                 {this.componentState.vallis.display && <VallisTimer vallisCycle={this.worldstate.vallisCycle} />}
                 {this.componentState.cambion.display && <CambionTimer cambionCycle={this.worldstate.cambionCycle} />}

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -80,8 +80,7 @@ export default {
     displayAggregate() {
       return (
         this.componentState.aggregated.display &&
-        (this.componentState.earth.display ||
-          this.componentState.cetus.display ||
+        (this.componentState.cetus.display ||
           this.componentState.vallis.display ||
           this.componentState.cambion.display ||
           this.componentState.reset.display ||

--- a/static/json/components.json
+++ b/static/json/components.json
@@ -29,23 +29,12 @@
   "cetus": {
     "display": true,
     "displayable": true,
-    "displayName": "Cetus Cycle",
+    "displayName": "Cetus/Earth Cycle",
     "key": "cetus",
     "component": "TimePanel",
     "props": {
       "time": "@worldstate.cetusCycle",
-      "location": "Cetus"
-    }
-  },
-  "earth": {
-    "display": true,
-    "displayable": true,
-    "displayName": "Earth Cycle",
-    "key": "earth",
-    "component": "TimePanel",
-    "props": {
-      "time": "@worldstate.earthCycle",
-      "location": "Earth"
+      "location": "Cetus/Earth"
     }
   },
   "vallis": {

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -105,9 +105,8 @@
     "siphon": "Kuva Siphon"
   },
   "location": {
-    "cetus": "Cetus",
+    "cetus": "Cetus/Earth",
     "vallis": "Vallis",
-    "earth": "Earth",
     "cambion": "Cambion",
     "zariman": "Zariman Ten Zero"
   },


### PR DESCRIPTION
**Summary:**
earth & cetus timers merged in 38.5.0
drop more earth

---
**Fixes issue (include link):**


---
**Mockups, screenshots, evidence:**




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Removed the Earth cycle time display from the main timer view.
  - Updated the display logic by eliminating Earth-specific conditions.
  - Consolidated cycle information so that Earth data now appears merged with the Cetus cycle, now labeled as "Cetus/Earth".
- **Bug Fixes**
  - Updated location references for the "cetus" component to provide clearer context.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->