### PR TITLE
fix: steel path fissure icon

### DIFF
--- a/components/panels/FissuresPanel.vue
+++ b/components/panels/FissuresPanel.vue
@@ -68,7 +68,7 @@ import HubPanelWrap from '@/components/HubPanelWrap.jsx';
 import { cdn } from '@/services/utilities';
 
 const archwing = cdn('svg/archwing.svg');
-const steelPath = cdn('svg/arbitrations.svg');
+const steelPath = cdn('svg/sp-logo.svg');
 
 const fissureIcons = [];
 const lith = cdn('svg/fissures/1.svg');


### PR DESCRIPTION
**Summary:**
Updating the icon used in the Fissures panel

---
**Fixes issue (include link):**
This replaces `arbitration.svg` with `sp-logo.svg`


---
**Mockups, screenshots, evidence:**
<img width="716" height="180" alt="image" src="https://github.com/user-attachments/assets/cf6e9602-cd54-4ed8-ba46-9c3b3cd1a322" />





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Replaced the hard-fissure icon with the current SP logo in the Fissures panel.
  * Improves visual clarity and brand consistency across lists and cards, making hard fissures easier to spot.
  * No functional changes, user actions, or settings required.
  * No public APIs or behaviors were altered; this is purely a visual asset update.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->