### PR TITLE
fix: update computed fields from worldstate removal

### DIFF
--- a/components/InvasionItem/InvasionItem.jsx
+++ b/components/InvasionItem/InvasionItem.jsx
@@ -1,8 +1,12 @@
+import relativeTime from 'dayjs/plugin/relativeTime';
+import dayjs from 'dayjs';
 import HubImg from '@/components/HubImg.jsx';
 import thumb from '@/components/AsyncItemThumb.jsx';
 import { makeid, cdn } from '@/services/utilities.js';
 
 import './InvasionItem.less';
+
+dayjs.extend(relativeTime);
 
 const corpus = cdn('svg/factions/corpus.svg');
 const corrupted = cdn('svg/factions/corrupted.svg');
@@ -85,11 +89,12 @@ export default {
   },
   methods: {
     eta(invasion) {
-      const eta = invasion.eta
-        .replace('-Infinityd', '??')
-        .replace('Infinityd', '??')
-        .replace(/\s\d\d?s/gi, '')
-        .trim();
+      const completedRuns = invasion.count;
+      const ellapsedMillis = dayjs(invasion.activation).diff(dayjs(), 'millisecond');
+      const remaining = invasion.requiredRuns - completedRuns;
+      const estExpiry = dayjs().add(remaining * (ellapsedMillis / completedRuns), 'millisecond');
+
+      const eta = dayjs(estExpiry).fromNow(true).trim();
       return `${this.$t('invasions.eta')} ${eta}`;
     },
   },
@@ -150,7 +155,7 @@ export default {
                 id={`${this.id}-defender-progress`}
                 variant={getLabelColor(this.invasion.defender.factionKey)}
                 value={100 - this.invasion.completion}
-                aria-label={`Current Defender Progresss: ${100 - this.invasion.completion}`}
+                aria-label={`Current Defender Progress: ${100 - this.invasion.completion}`}
               />
               <small class="justify-content-center d-flex position-absolute w-100 progress-value">
                 {this.invasion.completion.toFixed(2)}% - {this.eta(this.invasion)}
@@ -168,6 +173,7 @@ export default {
         </div>
       );
     } catch (e) {
+      console.error(e);
       console.error('Failed to render InvasionItem');
     }
     return <span />;

--- a/components/panels/AggregatedTimePanel.jsx
+++ b/components/panels/AggregatedTimePanel.jsx
@@ -119,10 +119,10 @@ const CambionTimer = {
   props: ['cambionCycle'],
   computed: {
     isCambionFass() {
-      return this.cambionCycle.active === 'fass';
+      return this.cambionCycle.state === 'fass';
     },
     isCambionVome() {
-      return this.cambionCycle.active === 'vome';
+      return this.cambionCycle.state === 'vome';
     },
   },
   render() {
@@ -134,7 +134,7 @@ const CambionTimer = {
           {this.isCambionFass && <i class="fa fa-sun fa-2x day" style={textStyle}></i>}
           {this.isCambionVome && <i class="fa fa-moon fa-2x night" style={textStyle}></i>}
           <br />
-          {this.$t(`time.${this.cambionCycle.active.toLowerCase()}`)}
+          {this.$t(`time.${this.cambionCycle.state.toLowerCase()}`)}
         </span>
         <br />
         <TimeBadge

--- a/components/panels/AlertPanel.jsx
+++ b/components/panels/AlertPanel.jsx
@@ -17,7 +17,7 @@ const Alert = {
   props: ['alert', 'index', 'last'],
   render() {
     return (
-      this.alert.active && (
+      new Date(this.alert.activation).getTime() < Date.now() && (
         <b-list-group-item
           key={this.alert.id}
           style={styles.inline}

--- a/components/panels/BountyPanel.vue
+++ b/components/panels/BountyPanel.vue
@@ -1,7 +1,7 @@
 <template>
   <HubPanelWrap :title="headertext" class="bounties">
     <b-list-group>
-      <b-list-group-item v-if="syndicate && syndicate.active" class="list-group-item-borderless">
+      <b-list-group-item v-if="active" class="list-group-item-borderless">
         <span class="pull-left">{{ $t('bounty.expires') }}</span>
         <TimeBadge :starttime="syndicate.activation" :endtime="syndicate.expiry" :interval="1000" />
         <b-table
@@ -42,7 +42,7 @@
           </template>
         </b-table>
       </b-list-group-item>
-      <b-list-group-item v-if="syndicate && syndicate.active" class="list-group-item-borderbottom">
+      <b-list-group-item v-if="active" class="list-group-item-borderbottom">
         <b-form-checkbox
           :id="`${typeId}-bounty-reward-checkbox`"
           v-model="check"
@@ -108,6 +108,10 @@ export default {
       id: makeid(),
       typeId: this.type.toLowerCase().replace(/\s/gi, '-'),
       autoExpand: false,
+      active: this.syndicate
+        ? new Date(this.syndicate.activation).getTime() < Date.now() &&
+          new Date(this.syndicate.expiry).getTime() > Date.now()
+        : false,
     };
   },
   computed: {

--- a/components/panels/ConstructionPanel.vue
+++ b/components/panels/ConstructionPanel.vue
@@ -45,6 +45,14 @@ import { VueEllipseProgress } from 'vue-ellipse-progress';
 import NoDataItem from '@/components/NoDataItem.jsx';
 import HubPanelWrap from '@/components/HubPanelWrap.jsx';
 
+const normalize = (num) => {
+  if (num > 100) {
+    return normalize(num - 100);
+  }
+  if (num < 0) return 0;
+  return num;
+};
+
 export default {
   name: 'ConstructionPanel',
   components: {
@@ -81,7 +89,10 @@ export default {
     },
   },
   methods: {
-    percent: (str) => Number.parseFloat(Number.parseFloat(str || '0.00').toFixed(2)),
+    percent: (str) => {
+      const num = normalize(Number.parseFloat(str || '0.00'));
+      return Number.parseFloat(num.toFixed(2));
+    },
   },
 };
 </script>


### PR DESCRIPTION
**Summary:**
fixes activity checks breakage from removal from worldstate

---
**Fixes issue (include link):**
N/A

---
**Mockups, screenshots, evidence:**
<img width="1656" height="1350" alt="image" src="https://github.com/user-attachments/assets/366c90c4-5781-403a-8ffa-08196bedf48b" />




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added new faction icons (Infested, Sentient) for invasion visuals.
  - Invasion ETAs now use precise time calculations and display relative “from now” text.

- Bug Fixes
  - Corrected Defender progress aria-label typo.
  - Improved render error logging for better stability.
  - Alerts and Bounties now appear only when truly active based on activation/expiry times.
  - Construction progress values are normalized to stay within 0–100 with consistent rounding.
  - Cambion cycle status now reflects the current state for more accurate timer labeling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->