### PR TITLE
ci: triggerable scorecard

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,5 +1,6 @@
 name: Scorecard
 on:
+  workflow_dispatch: {}
   workflow_run:
     workflows:
       - Release
@@ -30,6 +31,8 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
+          # Manual runs always score tip of dev (not the branch selected in the UI).
+          ref: ${{ github.event_name == 'workflow_dispatch' && 'dev' || github.sha }}
       - name: Run analysis
         uses: ossf/scorecard-action@2d1146689b8cda280b9bc96326124645441f03bc # v2.4.4
         with:


### PR DESCRIPTION
**Summary:**
make scorecard manually runnable

---
**Fixes issue (include link):**


---
**Mockups, screenshots, evidence:**




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added support for manually running the Scorecard workflow.
  * Manual runs now use the development branch, while automated runs continue to validate the triggering commit.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->